### PR TITLE
Update build process

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -15,5 +15,7 @@ stats/
 docs-ja/*.epub
 docs-ja/*.html
 docs-ja/mimetype
+docs-ja/po/*.pot
+docs-ja/po4a.cfg
 docs-ja/sed-out/
 docs-ja/translate-raw/

--- a/docs/docs-ja/Makefile
+++ b/docs/docs-ja/Makefile
@@ -23,10 +23,6 @@ TARGET_PO = $(addprefix $(PO_DIR)/,$(POFILES))
 TARGET_TEXI = $(TEXIPAGES)
 TARGET_TRANSLATE_RAW_TEXI = $(addprefix $(TRANSLATE_RAW_DIR)/,$(TEXIPAGES))
 
-# target_dir/hoge.ja.info -> src_dir/hoge.texi
-# $1 SRC_DIR, $2 target $3 .texi
-src_file = $(addsuffix $(3),$(addprefix $(1)/,$(notdir $(basename $(basename $(2))))))
-
 ## ###################################################################
 
 .PHONY: texi install clean AUTHORS.md stats
@@ -46,11 +42,18 @@ $(TARGET_SED_OUT): $(SED_OUT_DIR)/%.texi : $(SRC_DIR)/%.texi
 	@$(MKDIR) $(SED_OUT_DIR)
 	sed -f ./html-out.sed < $< > $@
 
-$(TARGET_PO): $(PO_DIR)/%.ja.po : $(SED_OUT_DIR)/%.texi
-	po4a-updatepo -M utf8 -f texinfo -m $< -p $@
+PO4A_CONFIG := po4a.cfg
 
-$(TARGET_TRANSLATE_RAW_TEXI): $(TRANSLATE_RAW_DIR)/%.ja.texi : $(PO_DIR)/%.ja.po
-	po4a-translate -f texinfo -keep 0 -M utf8 -m $(call src_file,$(SED_OUT_DIR),$@,.texi) -p $< -l $@
+$(PO4A_CONFIG):
+	PACKAGES='$(filter-out git-commit,$(PACKAGES))'	\
+	PO_DIR=$(PO_DIR)				\
+	SED_OUT_DIR=$(SED_OUT_DIR)			\
+	TARGET_PO='$(addprefix ja:,$(TARGET_PO))'	\
+	TRANSLATE_RAW_DIR=$(TRANSLATE_RAW_DIR)		\
+		./generate-po4a-config > $@
+
+$(TARGET_TRANSLATE_RAW_TEXI) &: $(TARGET_SED_OUT) $(TARGET_PO) $(PO4A_CONFIG)
+	po4a $(PO4A_CONFIG)
 
 $(TARGET_TEXI): %.ja.texi : $(TRANSLATE_RAW_DIR)/%.ja.texi
 	gawk -f fix-menu-wrap.awk $< > $@

--- a/docs/docs-ja/Makefile
+++ b/docs/docs-ja/Makefile
@@ -43,6 +43,7 @@ pdf:  $(PDFFILES)
 epub: $(EPUBFILES)
 
 $(TARGET_SED_OUT): $(SED_OUT_DIR)/%.texi : $(SRC_DIR)/%.texi
+	@$(MKDIR) $(SED_OUT_DIR)
 	sed -f ./html-out.sed < $< > $@
 
 $(TARGET_PO): $(PO_DIR)/%.ja.po : $(SED_OUT_DIR)/%.texi

--- a/docs/docs-ja/generate-po4a-config
+++ b/docs/docs-ja/generate-po4a-config
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+cat <<EOF
+[po4a_langs] ja
+[po4a_paths] $PO_DIR/\$master.pot \$lang:$PO_DIR/\$master.\$lang.po
+
+[options]                   \\
+  --master-charset UTF-8    \\
+  --localized-charset UTF-8 \\
+  --master-language en      \\
+  --keep 0
+
+EOF
+
+for package in $PACKAGES
+do
+    echo "[type:texinfo] $SED_OUT_DIR/$package.texi \$lang:$TRANSLATE_RAW_DIR/$package.\$lang.texi pot=$package"
+done

--- a/docs/docs-ja/magit-section.ja.info
+++ b/docs/docs-ja/magit-section.ja.info
@@ -113,11 +113,11 @@ File: magit-section.ja.info,  Node: Creating Sections,  Next: Core Functions,  P
      に設定され、BODYが評価された後、その‘end’が‘point’の新しい値に設定
      されます。BODYは、‘point’を前進させる責任があります。
 
-     If it turns out inside BODY that the section is empty, then
-     ‘magit-cancel-section’ can be used to abort and remove all traces
-     of the partially inserted section.  This can happen when creating a
-     section by washing Git’s output and Git didn’t actually output
-     anything this time around.
+     セクションが空であることがBODY内で判明した場合は、
+     ‘magit-cancel-section’を使用して、部分的に挿入されたセクションのす
+     べてのトレースを中止して削除できます。これは、Gitの出力を洗浄
+     (wash)してセクションを作成し、Gitが今回は実際には何も出力しなかった
+     場合に発生する可能性があります。
 
  -- Function: magit-insert-heading &rest args
      現在挿入されているセクションの見出しを挿入します。
@@ -253,17 +253,17 @@ File: magit-section.ja.info,  Node: Matching Functions,  Prev: Core Functions,  
         • ‘CLASS’ 親セクションのクラスには関係なく、セクションのクラスが
           CLASSまたはそのサブクラスと同じである場合に一致します。
 
-     Each CLASS should be a class symbol, identifying a class that
-     derives from ‘magit-section’.  For backward compatibility CLASS can
-     also be a "type symbol".  A section matches such a symbol if the
-     value of its ‘type’ slot is ‘eq’.  If a type symbol has an entry in
-     ‘magit--section-type-alist’, then a section also matches that type
-     if its class is a subclass of the class that corresponds to the
-     type as per that alist.
+     各CLASSは、‘magit-section’から派生したクラスを識別するクラスシンボ
+     ルである必要があります。下位互換性のために、CLASSは「タイプシンボル
+     」にすることもできます。‘type’スロットの値が‘eq’の場合、セクション
+     はそのようなシンボルに一致します。タイプシンボルの
+     ‘magit--section-type-alist’にエントリがある場合、そのクラスがその
+     alistのタイプに対応するクラスのサブクラスであれば、セクションもその
+     タイプに一致します。
 
-     Note that it is not necessary to specify the complete section
-     lineage as printed by ‘magit-describe-section-briefly’, unless of
-     course you want to be that precise.
+     注意: もちろん、正確にしたい場合を除いて、
+     ‘magit-describe-section-briefly’によって出力される完全なセクション
+     系統を指定する必要はないことに注意してください。
 
  -- Function: magit-section-value-if condition &optional section
      ポイントのセクションがCONDITIONと一致する場合は、その値を返します。
@@ -272,7 +272,8 @@ File: magit-section.ja.info,  Node: Matching Functions,  Prev: Core Functions,  
      かをテストします。ポイントにセクションがなく、SECTIONがnilの場合は
      、nilを返します。 セクションが一致しない場合は、nilを返します。
 
-     See ‘magit-section-match’ for the forms CONDITION can take.
+     CONDITIONが取ることができる形式については、‘magit-section-match’を
+     参照してください。
 
  -- Macro: magit-section-case &rest clauses
      ポイントのセクションのタイプに関する条項(clauses)から選択します。
@@ -294,8 +295,8 @@ Tag Table:
 Node: Top897
 Node: Introduction2570
 Node: Creating Sections3674
-Node: Core Functions9539
-Node: Matching Functions13639
+Node: Core Functions9651
+Node: Matching Functions13751
 
 End Tag Table
 

--- a/docs/docs-ja/magit-section.ja.info
+++ b/docs/docs-ja/magit-section.ja.info
@@ -1,5 +1,5 @@
-This is magit-section.ja.info, produced by makeinfo version 6.7 from
-magit-section.ja.texi.
+This is magit-section.ja.info, produced by .texi2any-real version 7.0.3
+from magit-section.ja.texi.
 
      Copyright (C) 2015-2022 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -49,10 +49,10 @@ Magitの一部として配布されていました。しかし今やMagitやGit�
 
 * Menu:
 
-* Introduction::
-* Creating Sections::
-* Core Functions::
-* Matching Functions::
+* Introduction::             Introduction
+* Creating Sections::        Creating Sections
+* Core Functions::           Core Functions
+* Matching Functions::       Matching Functions
 
 
 File: magit-section.ja.info,  Node: Introduction,  Next: Creating Sections,  Prev: Top,  Up: Top
@@ -113,11 +113,11 @@ File: magit-section.ja.info,  Node: Creating Sections,  Next: Core Functions,  P
      に設定され、BODYが評価された後、その‘end’が‘point’の新しい値に設定
      されます。BODYは、‘point’を前進させる責任があります。
 
-     セクションが空であることがBODY内で判明した場合は、
-     ‘magit-cancel-section’を使用して、部分的に挿入されたセクションのす
-     べてのトレースを中止して削除できます。これは、Gitの出力を洗浄
-     (wash)してセクションを作成し、Gitが今回は実際には何も出力しなかった
-     場合に発生する可能性があります。
+     If it turns out inside BODY that the section is empty, then
+     ‘magit-cancel-section’ can be used to abort and remove all traces
+     of the partially inserted section.  This can happen when creating a
+     section by washing Git’s output and Git didn’t actually output
+     anything this time around.
 
  -- Function: magit-insert-heading &rest args
      現在挿入されているセクションの見出しを挿入します。
@@ -253,17 +253,17 @@ File: magit-section.ja.info,  Node: Matching Functions,  Prev: Core Functions,  
         • ‘CLASS’ 親セクションのクラスには関係なく、セクションのクラスが
           CLASSまたはそのサブクラスと同じである場合に一致します。
 
-     各CLASSは、‘magit-section’から派生したクラスを識別するクラスシンボ
-     ルである必要があります。下位互換性のために、CLASSは"type symbol"に
-     することもできます。‘type’スロットの値が‘eq’の場合、セクションはそ
-     のようなシンボルに一致します。タイプシンボルの
-     ‘magit--section-type-alist’にエントリがある場合、そのクラスがその
-     alistのタイプに対応するクラスのサブクラスであれば、セクションもその
-     タイプに一致します。
+     Each CLASS should be a class symbol, identifying a class that
+     derives from ‘magit-section’.  For backward compatibility CLASS can
+     also be a "type symbol".  A section matches such a symbol if the
+     value of its ‘type’ slot is ‘eq’.  If a type symbol has an entry in
+     ‘magit--section-type-alist’, then a section also matches that type
+     if its class is a subclass of the class that corresponds to the
+     type as per that alist.
 
-     注意: もちろん、正確にしたい場合を除いて、
-     ‘magit-describe-section-briefly’によって出力される完全なセクション
-     系統を指定する必要はないことに注意してください。
+     Note that it is not necessary to specify the complete section
+     lineage as printed by ‘magit-describe-section-briefly’, unless of
+     course you want to be that precise.
 
  -- Function: magit-section-value-if condition &optional section
      ポイントのセクションがCONDITIONと一致する場合は、その値を返します。
@@ -272,7 +272,7 @@ File: magit-section.ja.info,  Node: Matching Functions,  Prev: Core Functions,  
      かをテストします。ポイントにセクションがなく、SECTIONがnilの場合は
      、nilを返します。 セクションが一致しない場合は、nilを返します。
 
-     CONDITIONが取ることができる形式については→‘magit-section-match’
+     See ‘magit-section-match’ for the forms CONDITION can take.
 
  -- Macro: magit-section-case &rest clauses
      ポイントのセクションのタイプに関する条項(clauses)から選択します。
@@ -291,11 +291,11 @@ File: magit-section.ja.info,  Node: Matching Functions,  Prev: Core Functions,  
 
 
 Tag Table:
-Node: Top889
-Node: Introduction2462
-Node: Creating Sections3566
-Node: Core Functions9543
-Node: Matching Functions13643
+Node: Top897
+Node: Introduction2570
+Node: Creating Sections3674
+Node: Core Functions9539
+Node: Matching Functions13639
 
 End Tag Table
 

--- a/docs/docs-ja/magit-section.ja.texi
+++ b/docs/docs-ja/magit-section.ja.texi
@@ -98,11 +98,7 @@ BODYは、セクションの見出しと本文を実際に挿入する任意の�
 
 BODYが評価される前に、セクションオブジェクトの@code{start}が`point'の値に設定され、BODYが評価された後、その@code{end}が@code{point}の新しい値に設定されます。BODYは、@code{point}を前進させる責任があります。
 
-If it turns out inside BODY that the section is empty, then
-@code{magit-cancel-section} can be used to abort and remove all traces of
-the partially inserted section.  This can happen when creating a section by
-washing Git's output and Git didn't actually output anything this time
-around.
+セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除できます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際には何も出力しなかった場合に発生する可能性があります。
 @end defmac
 
 @defun magit-insert-heading &rest args
@@ -210,17 +206,10 @@ CONDITIONは、以下の形式をとることができます:
 @code{CLASS} 親セクションのクラスには関係なく、セクションのクラスがCLASSまたはそのサブクラスと同じである場合に一致します。
 @end itemize
 
-Each CLASS should be a class symbol, identifying a class that derives from
-@code{magit-section}.  For backward compatibility CLASS can also be a "type
-symbol".  A section matches such a symbol if the value of its @code{type}
-slot is @code{eq}.  If a type symbol has an entry in
-@code{magit--section-type-alist}, then a section also matches that type if
-its class is a subclass of the class that corresponds to the type as per
-that alist.
+各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルである必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもできます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリがある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、セクションもそのタイプに一致します。
 
-Note that it is not necessary to specify the complete section lineage as
-printed by @code{magit-describe-section-briefly}, unless of course you want
-to be that precise.
+注意:
+もちろん、正確にしたい場合を除いて、@code{magit-describe-section-briefly}によって出力される完全なセクション系統を指定する必要はないことに注意してください。
 @end defun
 
 @defun magit-section-value-if condition &optional section
@@ -229,7 +218,7 @@ to be that precise.
 オプションのSECTIONがnil以外の場合は、代わりにそれが一致するかどうかをテストします。ポイントにセクションがなく、SECTIONがnilの場合は、nilを返します。
 セクションが一致しない場合は、nilを返します。
 
-See @code{magit-section-match} for the forms CONDITION can take.
+CONDITIONが取ることができる形式については、@code{magit-section-match}を参照してください。
 @end defun
 
 @defmac magit-section-case &rest clauses

--- a/docs/docs-ja/magit-section.ja.texi
+++ b/docs/docs-ja/magit-section.ja.texi
@@ -4,6 +4,7 @@
 @c This file was generated with po4a. Translate the source file.
 @c
 @c ===========================================================================
+
 @c %**start of header
 @setfilename magit-section.info
 @settitle Magit-Section Developer Manual
@@ -60,10 +61,10 @@ more details.
 @end ifnottex
 
 @menu
-* Introduction::
-* Creating Sections::
-* Core Functions::
-* Matching Functions::       
+* Introduction::             Introduction
+* Creating Sections::        Creating Sections
+* Core Functions::           Core Functions
+* Matching Functions::       Matching Functions
 @end menu
 
 @node Introduction
@@ -97,7 +98,11 @@ BODYは、セクションの見出しと本文を実際に挿入する任意の�
 
 BODYが評価される前に、セクションオブジェクトの@code{start}が`point'の値に設定され、BODYが評価された後、その@code{end}が@code{point}の新しい値に設定されます。BODYは、@code{point}を前進させる責任があります。
 
-セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除できます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際には何も出力しなかった場合に発生する可能性があります。
+If it turns out inside BODY that the section is empty, then
+@code{magit-cancel-section} can be used to abort and remove all traces of
+the partially inserted section.  This can happen when creating a section by
+washing Git's output and Git didn't actually output anything this time
+around.
 @end defmac
 
 @defun magit-insert-heading &rest args
@@ -205,11 +210,17 @@ CONDITIONは、以下の形式をとることができます:
 @code{CLASS} 親セクションのクラスには関係なく、セクションのクラスがCLASSまたはそのサブクラスと同じである場合に一致します。
 @end itemize
 
-各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルである必要があります。下位互換性のために、CLASSは"type
-symbol"にすることもできます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリがある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、セクションもそのタイプに一致します。
+Each CLASS should be a class symbol, identifying a class that derives from
+@code{magit-section}.  For backward compatibility CLASS can also be a "type
+symbol".  A section matches such a symbol if the value of its @code{type}
+slot is @code{eq}.  If a type symbol has an entry in
+@code{magit--section-type-alist}, then a section also matches that type if
+its class is a subclass of the class that corresponds to the type as per
+that alist.
 
-注意:
-もちろん、正確にしたい場合を除いて、@code{magit-describe-section-briefly}によって出力される完全なセクション系統を指定する必要はないことに注意してください。
+Note that it is not necessary to specify the complete section lineage as
+printed by @code{magit-describe-section-briefly}, unless of course you want
+to be that precise.
 @end defun
 
 @defun magit-section-value-if condition &optional section
@@ -218,7 +229,7 @@ symbol"にすることもできます。@code{type}スロットの値が@code{eq
 オプションのSECTIONがnil以外の場合は、代わりにそれが一致するかどうかをテストします。ポイントにセクションがなく、SECTIONがnilの場合は、nilを返します。
 セクションが一致しない場合は、nilを返します。
 
-CONDITIONが取ることができる形式については→@code{magit-section-match}
+See @code{magit-section-match} for the forms CONDITION can take.
 @end defun
 
 @defmac magit-section-case &rest clauses

--- a/docs/docs-ja/magit.ja.info
+++ b/docs/docs-ja/magit.ja.info
@@ -1,4 +1,4 @@
-This is magit.ja.info, produced by makeinfo version 6.7 from
+This is magit.ja.info, produced by .texi2any-real version 7.0.3 from
 magit.ja.texi.
 
      Copyright (C) 2015-2022 Jonas Bernoulli <jonas@bernoul.li>
@@ -49,21 +49,21 @@ This manual is for Magit version 3.3.0-git.
 
 * Menu:
 
-* Introduction::
-* Installation::
-* Getting Started::
-* Interface Concepts::
-* Inspecting::
-* Manipulating::
-* Transferring::
-* Miscellaneous::
-* Customizing::
-* 配管コマンド(Plumbing)::
-* FAQ::
-* Debugging Tools::
-* Keystroke Index::
-* Function and Command Index::
-* Variable Index::
+* Introduction::             Introduction
+* Installation::             Installation
+* Getting Started::          Getting Started
+* Interface Concepts::       Interface Concepts
+* Inspecting::               Inspecting
+* Manipulating::             Manipulating
+* Transferring::             Transferring
+* Miscellaneous::            Miscellaneous
+* Customizing::              Customizing
+* 配管コマンド(Plumbing)::  配管コマンド(Plumbing)
+* FAQ::                      FAQ
+* Debugging Tools::          Debugging Tools
+* Keystroke Index::          Keystroke Index
+* Function and Command Index::  Function and Command Index
+* Variable Index::           Variable Index
 
 — The Detailed Node Listing —
 
@@ -73,32 +73,38 @@ Installation
 
 
 
-* Installing from Melpa::
-* Installing from the Git Repository::
-* Post-Installation Tasks::
+* Installing from Melpa::    Installing from Melpa
+* Installing from the Git Repository::  Installing from the Git Repository
+* Post-Installation Tasks::  Post-Installation Tasks
 
 Interface Concepts
 
 
 
-* Modes and Buffers::
-* Sections::
-* トランジェントコマンド::
-* Transient Arguments and Buffer Variables::
-* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).
-* Mouse Support::
-* Running Git::
+* Modes and Buffers::        Modes and Buffers
+* Sections::                 Sections
+* トランジェントコマンド::  トランジェントコマンド
+* Transient Arguments and Buffer Variables::  Transient Arguments and Buffer
+                                                Variables
+* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).  Completion(補完)とConfirmation(確認)とSelection(選択範囲):
+                                                                                                                                           Completion
+                                                                                                                                           Confirmation(確認補完)とSelection(選択範囲)
+* Mouse Support::            Mouse Support
+* Running Git::              Running Git
 
 Modes and Buffers
 
 
 
-* バッファの切り替え::
-* バッファの名付け::
-* Quitting Windows::
-* Automatic Refreshing of Magit Buffers::
-* Automatic Saving of File-Visiting Buffers::
-* Automatic Reverting of File-Visiting Buffers::
+* バッファの切り替え::  バッファの切り替え
+* バッファの名付け::  バッファの名付け
+* Quitting Windows::         Quitting Windows
+* Automatic Refreshing of Magit Buffers::  Automatic Refreshing of Magit
+                                             Buffers
+* Automatic Saving of File-Visiting Buffers::  Automatic Saving of
+                                                 File-Visiting Buffers
+* Automatic Reverting of File-Visiting Buffers::  Automatic Reverting of
+                                                    File-Visiting Buffers
 
 
 
@@ -106,11 +112,11 @@ Sections
 
 
 
-* Section Movement::
-* Section Visibility::
-* Section Hooks::
-* Section Types and Values::
-* Section Options::
+* Section Movement::         Section Movement
+* Section Visibility::       Section Visibility
+* Section Hooks::            Section Hooks
+* Section Types and Values::  Section Types and Values
+* Section Options::          Section Options
 
 
 
@@ -118,12 +124,12 @@ Completion(補完)とConfirmation(確認)とSelection(選択範囲)
 
 
 
-* アクションの確認::
-* 補完と確認::
-* 選択範囲::
-* ハンク内部リージョン::
-* 補完フレームワークのサポート::
-* 追加の補完オプション::
+* アクションの確認::  アクションの確認
+* 補完と確認::          補完と確認
+* 選択範囲::             選択範囲
+* ハンク内部リージョン::  ハンク内部リージョン
+* 補完フレームワークのサポート::  補完フレームワークのサポート
+* 追加の補完オプション::  追加の補完オプション
 
 
 
@@ -131,11 +137,11 @@ Running Git
 
 
 
-* Viewing Git Output::
-* Git Process Status::
-* Gitを手動で実行::
-* Git実行ファイル::
-* Global Git Arguments::
+* Viewing Git Output::       Viewing Git Output
+* Git Process Status::       Git Process Status
+* Gitを手動で実行::    Gitを手動で実行
+* Git実行ファイル::    Git実行ファイル
+* Global Git Arguments::     Global Git Arguments
 
 
 
@@ -143,24 +149,24 @@ Inspecting
 
 
 
-* Status Buffer::
-* Repository List::
-* Logging::
-* Diffing::
-* Ediffing::
-* References Buffer::
-* Bisecting::
-* Visiting Files and Blobs::
-* Blaming::
+* Status Buffer::            Status Buffer
+* Repository List::          Repository List
+* Logging::                  Logging
+* Diffing::                  Diffing
+* Ediffing::                 Ediffing
+* References Buffer::        References Buffer
+* Bisecting::                Bisecting
+* Visiting Files and Blobs::  Visiting Files and Blobs
+* Blaming::                  Blaming
 
 Status Buffer
 
 
 
-* Status Sections::
-* Status Header Sections::
-* Status Module Sections::
-* Status Options::
+* Status Sections::          Status Sections
+* Status Header Sections::   Status Header Sections
+* Status Module Sections::   Status Module Sections
+* Status Options::           Status Options
 
 
 
@@ -168,12 +174,12 @@ Logging
 
 
 
-* Refreshing Logs::
-* Log Buffer::
-* Log Margin::
-* Select from Log::
-* Reflog::
-* Cherries::
+* Refreshing Logs::          Refreshing Logs
+* Log Buffer::               Log Buffer
+* Log Margin::               Log Margin
+* Select from Log::          Select from Log
+* Reflog::                   Reflog
+* Cherries::                 Cherries
 
 
 
@@ -181,10 +187,10 @@ Diffing
 
 
 
-* Refreshing Diffs::
-* Commands Available in Diffs::
-* Diff Options::
-* Revision Buffer::
+* Refreshing Diffs::         Refreshing Diffs
+* Commands Available in Diffs::  Commands Available in Diffs
+* Diff Options::             Diff Options
+* Revision Buffer::          Revision Buffer
 
 
 
@@ -192,7 +198,7 @@ References Buffer
 
 
 
-* References Sections::
+* References Sections::      References Sections
 
 
 
@@ -200,8 +206,9 @@ Visiting Files and Blobs
 
 
 
-* General-Purpose Visit Commands::
-* Visiting Files and Blobs from a Diff::
+* General-Purpose Visit Commands::  General-Purpose Visit Commands
+* Visiting Files and Blobs from a Diff::  Visiting Files and Blobs from a
+                                            Diff
 
 
 
@@ -209,24 +216,24 @@ Manipulating
 
 
 
-* Creating Repository::
-* Cloning Repository::
-* Staging and Unstaging::
-* Applying::
-* Committing::
-* Branching::
-* Merging::
-* Resolving Conflicts::
-* Rebasing::
-* Cherry Picking::
-* Resetting::
-* Stashing::
+* Creating Repository::      Creating Repository
+* Cloning Repository::       Cloning Repository
+* Staging and Unstaging::    Staging and Unstaging
+* Applying::                 Applying
+* Committing::               Committing
+* Branching::                Branching
+* Merging::                  Merging
+* Resolving Conflicts::      Resolving Conflicts
+* Rebasing::                 Rebasing
+* Cherry Picking::           Cherry Picking
+* Resetting::                Resetting
+* Stashing::                 Stashing
 
 Staging and Unstaging
 
 
 
-* Staging from File-Visiting Buffers::
+* Staging from File-Visiting Buffers::  Staging from File-Visiting Buffers
 
 
 
@@ -234,8 +241,8 @@ Committing
 
 
 
-* コミット開始::
-* Editing Commit Messages::
+* コミット開始::       コミット開始
+* Editing Commit Messages::  Editing Commit Messages
 
 
 
@@ -243,10 +250,10 @@ Branching
 
 
 
-* The Two Remotes::
-* Branch Commands::
-* Branch Git Variables::
-* Auxiliary Branch Commands::
+* The Two Remotes::          The Two Remotes
+* Branch Commands::          Branch Commands
+* Branch Git Variables::     Branch Git Variables
+* Auxiliary Branch Commands::  Auxiliary Branch Commands
 
 
 
@@ -254,8 +261,9 @@ Rebasing
 
 
 
-* Editing Rebase Sequences::
-* Information About In-Progress Rebase::
+* Editing Rebase Sequences::  Editing Rebase Sequences
+* Information About In-Progress Rebase::  Information About In-Progress
+                                            Rebase
 
 
 
@@ -263,7 +271,7 @@ Cherry Picking
 
 
 
-* Reverting::
+* Reverting::                Reverting
 
 
 
@@ -271,19 +279,19 @@ Transferring
 
 
 
-* Remotes::
-* Fetching::
-* Pulling::
-* Pushing::
-* Plain Patches::
-* Maildir Patches::
+* Remotes::                  Remotes
+* Fetching::                 Fetching
+* Pulling::                  Pulling
+* Pushing::                  Pushing
+* Plain Patches::            Plain Patches
+* Maildir Patches::          Maildir Patches
 
 Remotes
 
 
 
-* Remote Commands::
-* Remote Git Variables::
+* Remote Commands::          Remote Commands
+* Remote Git Variables::     Remote Git Variables
 
 
 
@@ -291,24 +299,25 @@ Miscellaneous
 
 
 
-* Tagging::
-* Notes::
-* Submodules::
-* Subtree::
-* Worktree::
-* Sparse checkouts::
-* Bundle::
-* Common Commands::
-* Wip Modes::
-* Commands for Buffers Visiting Files::
-* Minor Mode for Buffers Visiting Blobs::
+* Tagging::                  Tagging
+* Notes::                    Notes
+* Submodules::               Submodules
+* Subtree::                  Subtree
+* Worktree::                 Worktree
+* Sparse checkouts::         Sparse checkouts
+* Bundle::                   Bundle
+* Common Commands::          Common Commands
+* Wip Modes::                Wip Modes
+* Commands for Buffers Visiting Files::  Commands for Buffers Visiting Files
+* Minor Mode for Buffers Visiting Blobs::  Minor Mode for Buffers Visiting
+                                             Blobs
 
 Submodules
 
 
 
-* Listing Submodules::
-* submodule用トランジェントコマンド::
+* Listing Submodules::       Listing Submodules
+* submodule用トランジェントコマンド::  submodule用トランジェントコマンド
 
 
 
@@ -316,8 +325,8 @@ Wip Modes
 
 
 
-* Wip Graph::
-* Legacy Wip Modes::
+* Wip Graph::                Wip Graph
+* Legacy Wip Modes::         Legacy Wip Modes
 
 
 
@@ -325,16 +334,16 @@ Customizing
 
 
 
-* Per-Repository Configuration::
-* 基本設定::
+* Per-Repository Configuration::  Per-Repository Configuration
+* 基本設定::             基本設定
 
 基本設定
 
 
 
-* Safety::
-* Performance::
-* Default Bindings::
+* Safety::                   Safety
+* Performance::              Performance
+* Default Bindings::         Default Bindings
 
 
 
@@ -342,17 +351,17 @@ Customizing
 
 
 
-* Calling Git::
-* Section Plumbing::
-* Refreshing Buffers::
-* 慣習::
+* Calling Git::              Calling Git
+* Section Plumbing::         Section Plumbing
+* Refreshing Buffers::       Refreshing Buffers
+* 慣習::                   慣習
 
 Calling Git
 
 
 
-* Getting a Value from Git::
-* Calling Git for Effect::
+* Getting a Value from Git::  Getting a Value from Git
+* Calling Git for Effect::   Calling Git for Effect
 
 
 
@@ -360,9 +369,9 @@ Section Plumbing
 
 
 
-* Creating Sections::
-* Section Selection::
-* Matching Sections::
+* Creating Sections::        Creating Sections
+* Section Selection::        Section Selection
+* Matching Sections::        Matching Sections
 
 
 
@@ -370,7 +379,7 @@ Section Plumbing
 
 
 
-* Theming Faces::
+* Theming Faces::            Theming Faces
 
 
 
@@ -378,19 +387,22 @@ FAQ
 
 
 
-* FAQ - How to ...?::
-* FAQ - Issues and Errors::
+* FAQ - How to ...?::    FAQ - How to ...?
+* FAQ - Issues and Errors::  FAQ - Issues and Errors
 
 FAQ - How to ...?
 
 
 
-* Magitの発音は？::
-* How to show git's output?::
-* How to install the gitman info manual?::
-* How to show diffs for gpg-encrypted files?::
-* How does branching and pushing work?::
-* VCを無効にする必要がありますか？::
+* Magitの発音は？::     Magitの発音は？
+* How to show git's output?::  How to show git’s output?
+* How to install the gitman info manual?::  How to install the gitman info
+                                              manual?
+* How to show diffs for gpg-encrypted files?::  How to show diffs for
+                                                  gpg-encrypted files?
+* How does branching and pushing work?::  How does branching and pushing
+                                            work?
+* VCを無効にする必要がありますか？::  VCを無効にする必要がありますか？
 
 
 
@@ -398,20 +410,37 @@ FAQ - Issues and Errors
 
 
 
-* Magit is slow::
-* I changed several thousand files at once and now Magit is unusable::
-* コミットに問題があります::
-* MS WindowsではMagitでpushできません::
-* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.
-* ファイルを展開してdiffを表示するとファイルが消えます::
-* COMMIT_EDITMSGバッファのpointが間違っています::
-* モード行の情報が常に最新ではない::
-* 同じ名前を共有するブランチとタグは何かを壊します::
-* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::
-* コマンドラインからコミットする場合、git-commit-modeは使用されません::
-* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::
-* MS-WindowsからEmacsのTrampモードを使用するとステージできません::
-* 私はポップアップのデフォルトを保存できなくなりました::
+* Magit is slow::            Magit is slow
+* I changed several thousand files at once and now Magit is unusable::  I
+                                                                          changed
+                                                                          several
+                                                                          thousand
+                                                                          files
+                                                                          at
+                                                                          once
+                                                                          and
+                                                                          now
+                                                                          Magit
+                                                                          is
+                                                                          unusable
+* コミットに問題があります::  コミットに問題があります
+* MS WindowsではMagitでpushできません::  MS
+                                                   WindowsではMagitでpushできません
+* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.  私は
+                                                                                                                                                                                                                                             macOS
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません:
+                                                                                                                                                                                                                                             私は
+                                                                                                                                                                                                                                             macOS
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません
+* ファイルを展開してdiffを表示するとファイルが消えます::  ファイルを展開してdiffを表示するとファイルが消えます
+* COMMIT_EDITMSGバッファのpointが間違っています::  ‘COMMIT_EDITMSG’バッファのpointが間違っています
+* モード行の情報が常に最新ではない::  モード行の情報が常に最新ではない
+* 同じ名前を共有するブランチとタグは何かを壊します::  同じ名前を共有するブランチとタグは何かを壊します
+* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::  私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません
+* コマンドラインからコミットする場合、git-commit-modeは使用されません::  コマンドラインからコミットする場合、‘git-commit-mode’は使用されません
+* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::  file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります
+* MS-WindowsからEmacsのTrampモードを使用するとステージできません::  MS-WindowsからEmacsのTrampモードを使用するとステージできません
+* 私はポップアップのデフォルトを保存できなくなりました::  私はポップアップのデフォルトを保存できなくなりました
 
 
 
@@ -510,9 +539,9 @@ Magitは、Emacsのパッケージマネージャーを使用してインスト�
 
 * Menu:
 
-* Installing from Melpa::
-* Installing from the Git Repository::
-* Post-Installation Tasks::
+* Installing from Melpa::    Installing from Melpa
+* Installing from the Git Repository::  Installing from the Git Repository
+* Post-Installation Tasks::  Post-Installation Tasks
 
 
 File: magit.ja.info,  Node: Installing from Melpa,  Next: Installing from the Git Repository,  Up: Installation
@@ -772,13 +801,16 @@ File: magit.ja.info,  Node: Interface Concepts,  Next: Inspecting,  Prev: Gettin
 
 * Menu:
 
-* Modes and Buffers::
-* Sections::
-* トランジェントコマンド::
-* Transient Arguments and Buffer Variables::
-* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).
-* Mouse Support::
-* Running Git::
+* Modes and Buffers::        Modes and Buffers
+* Sections::                 Sections
+* トランジェントコマンド::  トランジェントコマンド
+* Transient Arguments and Buffer Variables::  Transient Arguments and Buffer
+                                                Variables
+* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).  Completion(補完)とConfirmation(確認)とSelection(選択範囲):
+                                                                                                                                           Completion
+                                                                                                                                           Confirmation(確認補完)とSelection(選択範囲)
+* Mouse Support::            Mouse Support
+* Running Git::              Running Git
 
 
 File: magit.ja.info,  Node: Modes and Buffers,  Next: Sections,  Up: Interface Concepts
@@ -818,12 +850,15 @@ Magitはいくつかのメジャーモードを提供します。 これらの�
 
 * Menu:
 
-* バッファの切り替え::
-* バッファの名付け::
-* Quitting Windows::
-* Automatic Refreshing of Magit Buffers::
-* Automatic Saving of File-Visiting Buffers::
-* Automatic Reverting of File-Visiting Buffers::
+* バッファの切り替え::  バッファの切り替え
+* バッファの名付け::  バッファの名付け
+* Quitting Windows::         Quitting Windows
+* Automatic Refreshing of Magit Buffers::  Automatic Refreshing of Magit
+                                             Buffers
+* Automatic Saving of File-Visiting Buffers::  Automatic Saving of
+                                                 File-Visiting Buffers
+* Automatic Reverting of File-Visiting Buffers::  Automatic Reverting of
+                                                    File-Visiting Buffers
 
 
 File: magit.ja.info,  Node: バッファの切り替え,  Next: バッファの名付け,  Up: Modes and Buffers
@@ -1238,7 +1273,7 @@ revertするのはかなり重要な機能です。
 
 * Menu:
 
-* Risk of Reverting Automatically::
+* Risk of Reverting Automatically::  Risk of Reverting Automatically
 
 
 File: magit.ja.info,  Node: Risk of Reverting Automatically,  Up: Automatic Reverting of File-Visiting Buffers
@@ -1302,11 +1337,11 @@ Magitバッファはネストされたセクションに編成され、Orgモー
 
 * Menu:
 
-* Section Movement::
-* Section Visibility::
-* Section Hooks::
-* Section Types and Values::
-* Section Options::
+* Section Movement::         Section Movement
+* Section Visibility::       Section Visibility
+* Section Hooks::            Section Hooks
+* Section Types and Values::  Section Types and Values
+* Section Options::          Section Options
 
 
 File: magit.ja.info,  Node: Section Movement,  Next: Section Visibility,  Up: Sections
@@ -1813,12 +1848,12 @@ File: magit.ja.info,  Node: Completion Confirmation(確認補完)とSelection(�
 
 * Menu:
 
-* アクションの確認::
-* 補完と確認::
-* 選択範囲::
-* ハンク内部リージョン::
-* 補完フレームワークのサポート::
-* 追加の補完オプション::
+* アクションの確認::  アクションの確認
+* 補完と確認::          補完と確認
+* 選択範囲::             選択範囲
+* ハンク内部リージョン::  ハンク内部リージョン
+* 補完フレームワークのサポート::  補完フレームワークのサポート
+* 追加の補完オプション::  追加の補完オプション
 
 
 File: magit.ja.info,  Node: アクションの確認,  Next: 補完と確認,  Up: Completion Confirmation(確認補完)とSelection(選択範囲)
@@ -2258,11 +2293,11 @@ File: magit.ja.info,  Node: Running Git,  Prev: Mouse Support,  Up: Interface Co
 
 * Menu:
 
-* Viewing Git Output::
-* Git Process Status::
-* Gitを手動で実行::
-* Git実行ファイル::
-* Global Git Arguments::
+* Viewing Git Output::       Viewing Git Output
+* Git Process Status::       Git Process Status
+* Gitを手動で実行::    Gitを手動で実行
+* Git実行ファイル::    Git実行ファイル
+* Global Git Arguments::     Global Git Arguments
 
 
 File: magit.ja.info,  Node: Viewing Git Output,  Next: Git Process Status,  Up: Running Git
@@ -2522,15 +2557,15 @@ Magitが提供する機能は、既存のデータの検査、既存のデータ
 
 * Menu:
 
-* Status Buffer::
-* Repository List::
-* Logging::
-* Diffing::
-* Ediffing::
-* References Buffer::
-* Bisecting::
-* Visiting Files and Blobs::
-* Blaming::
+* Status Buffer::            Status Buffer
+* Repository List::          Repository List
+* Logging::                  Logging
+* Diffing::                  Diffing
+* Ediffing::                 Ediffing
+* References Buffer::        References Buffer
+* Bisecting::                Bisecting
+* Visiting Files and Blobs::  Visiting Files and Blobs
+* Blaming::                  Blaming
 
 
 File: magit.ja.info,  Node: Status Buffer,  Next: Repository List,  Up: Inspecting
@@ -2646,10 +2681,10 @@ diff、プッシュされていないコミットとプルされていないコ�
 
 * Menu:
 
-* Status Sections::
-* Status Header Sections::
-* Status Module Sections::
-* Status Options::
+* Status Sections::          Status Sections
+* Status Header Sections::   Status Header Sections
+* Status Module Sections::   Status Module Sections
+* Status Options::           Status Options
 
 
 File: magit.ja.info,  Node: Status Sections,  Next: Status Header Sections,  Up: Status Buffer
@@ -3142,12 +3177,12 @@ Transient Arguments and Buffer Variables::)。
 
 * Menu:
 
-* Refreshing Logs::
-* Log Buffer::
-* Log Margin::
-* Select from Log::
-* Reflog::
-* Cherries::
+* Refreshing Logs::          Refreshing Logs
+* Log Buffer::               Log Buffer
+* Log Margin::               Log Margin
+* Select from Log::          Select from Log
+* Reflog::                   Reflog
+* Cherries::                 Cherries
 
 
 File: magit.ja.info,  Node: Refreshing Logs,  Next: Log Buffer,  Up: Logging
@@ -3566,10 +3601,10 @@ Visiting Files::)。
 
 * Menu:
 
-* Refreshing Diffs::
-* Commands Available in Diffs::
-* Diff Options::
-* Revision Buffer::
+* Refreshing Diffs::         Refreshing Diffs
+* Commands Available in Diffs::  Commands Available in Diffs
+* Diff Options::             Diff Options
+* Revision Buffer::          Revision Buffer
 
 
 File: magit.ja.info,  Node: Refreshing Diffs,  Next: Commands Available in Diffs,  Up: Diffing
@@ -4276,7 +4311,7 @@ File: magit.ja.info,  Node: References Buffer,  Next: Bisecting,  Prev: Ediffing
 
 * Menu:
 
-* References Sections::
+* References Sections::      References Sections
 
 
 File: magit.ja.info,  Node: References Sections,  Up: References Buffer
@@ -4381,8 +4416,9 @@ Magitは、ファイルまたはblob(特定のコミットに保存されてい�
 
 * Menu:
 
-* General-Purpose Visit Commands::
-* Visiting Files and Blobs from a Diff::
+* General-Purpose Visit Commands::  General-Purpose Visit Commands
+* Visiting Files and Blobs from a Diff::  Visiting Files and Blobs from a
+                                            Diff
 
 
 File: magit.ja.info,  Node: General-Purpose Visit Commands,  Next: Visiting Files and Blobs from a Diff,  Up: Visiting Files and Blobs
@@ -4647,18 +4683,18 @@ File: magit.ja.info,  Node: Manipulating,  Next: Transferring,  Prev: Inspecting
 
 * Menu:
 
-* Creating Repository::
-* Cloning Repository::
-* Staging and Unstaging::
-* Applying::
-* Committing::
-* Branching::
-* Merging::
-* Resolving Conflicts::
-* Rebasing::
-* Cherry Picking::
-* Resetting::
-* Stashing::
+* Creating Repository::      Creating Repository
+* Cloning Repository::       Cloning Repository
+* Staging and Unstaging::    Staging and Unstaging
+* Applying::                 Applying
+* Committing::               Committing
+* Branching::                Branching
+* Merging::                  Merging
+* Resolving Conflicts::      Resolving Conflicts
+* Rebasing::                 Rebasing
+* Cherry Picking::           Cherry Picking
+* Resetting::                Resetting
+* Stashing::                 Stashing
 
 
 File: magit.ja.info,  Node: Creating Repository,  Next: Cloning Repository,  Up: Manipulating
@@ -4905,7 +4941,7 @@ File: magit.ja.info,  Node: Staging and Unstaging,  Next: Applying,  Prev: Cloni
 
 * Menu:
 
-* Staging from File-Visiting Buffers::
+* Staging from File-Visiting Buffers::  Staging from File-Visiting Buffers
 
 
 File: magit.ja.info,  Node: Staging from File-Visiting Buffers,  Up: Staging and Unstaging
@@ -5007,8 +5043,8 @@ Magitは、そのエディターがEmacsclientになるように手配します�
 
 * Menu:
 
-* コミット開始::
-* Editing Commit Messages::
+* コミット開始::       コミット開始
+* Editing Commit Messages::  Editing Commit Messages
 
 
 File: magit.ja.info,  Node: コミット開始,  Next: Editing Commit Messages,  Up: Committing
@@ -5201,10 +5237,10 @@ File: magit.ja.info,  Node: Editing Commit Messages,  Prev: コミット開始, 
 
 * Menu:
 
-* Using the Revision Stack::
-* Commit Pseudo Headers::
-* Commit Mode and Hooks::
-* Commit Message Conventions::
+* Using the Revision Stack::  Using the Revision Stack
+* Commit Pseudo Headers::    Commit Pseudo Headers
+* Commit Mode and Hooks::    Commit Mode and Hooks
+* Commit Message Conventions::  Commit Message Conventions
 
 
 File: magit.ja.info,  Node: Using the Revision Stack,  Next: Commit Pseudo Headers,  Up: Editing Commit Messages
@@ -5434,10 +5470,10 @@ File: magit.ja.info,  Node: Branching,  Next: Merging,  Prev: Committing,  Up: M
 
 * Menu:
 
-* The Two Remotes::
-* Branch Commands::
-* Branch Git Variables::
-* Auxiliary Branch Commands::
+* The Two Remotes::          The Two Remotes
+* Branch Commands::          Branch Commands
+* Branch Git Variables::     Branch Git Variables
+* Auxiliary Branch Commands::  Auxiliary Branch Commands
 
 
 File: magit.ja.info,  Node: The Two Remotes,  Next: Branch Commands,  Up: Branching
@@ -6234,8 +6270,9 @@ In-Progress Rebase::)。
 
 * Menu:
 
-* Editing Rebase Sequences::
-* Information About In-Progress Rebase::
+* Editing Rebase Sequences::  Editing Rebase Sequences
+* Information About In-Progress Rebase::  Information About In-Progress
+                                            Rebase
 
 
 File: magit.ja.info,  Node: Editing Rebase Sequences,  Next: Information About In-Progress Rebase,  Up: Rebasing
@@ -6629,7 +6666,7 @@ cherry-pickまたはrevertが進行中の場合、トランジェントコマン
 
 * Menu:
 
-* Reverting::
+* Reverting::                Reverting
 
 
 File: magit.ja.info,  Node: Reverting,  Up: Cherry Picking
@@ -6847,12 +6884,12 @@ File: magit.ja.info,  Node: Transferring,  Next: Miscellaneous,  Prev: Manipulat
 
 * Menu:
 
-* Remotes::
-* Fetching::
-* Pulling::
-* Pushing::
-* Plain Patches::
-* Maildir Patches::
+* Remotes::                  Remotes
+* Fetching::                 Fetching
+* Pulling::                  Pulling
+* Pushing::                  Pushing
+* Plain Patches::            Plain Patches
+* Maildir Patches::          Maildir Patches
 
 
 File: magit.ja.info,  Node: Remotes,  Next: Fetching,  Up: Transferring
@@ -6862,8 +6899,8 @@ File: magit.ja.info,  Node: Remotes,  Next: Fetching,  Up: Transferring
 
 * Menu:
 
-* Remote Commands::
-* Remote Git Variables::
+* Remote Commands::          Remote Commands
+* Remote Git Variables::     Remote Git Variables
 
 
 File: magit.ja.info,  Node: Remote Commands,  Next: Remote Git Variables,  Up: Remotes
@@ -7299,17 +7336,18 @@ File: magit.ja.info,  Node: Miscellaneous,  Next: Customizing,  Prev: Transferri
 
 * Menu:
 
-* Tagging::
-* Notes::
-* Submodules::
-* Subtree::
-* Worktree::
-* Sparse checkouts::
-* Bundle::
-* Common Commands::
-* Wip Modes::
-* Commands for Buffers Visiting Files::
-* Minor Mode for Buffers Visiting Blobs::
+* Tagging::                  Tagging
+* Notes::                    Notes
+* Submodules::               Submodules
+* Subtree::                  Subtree
+* Worktree::                 Worktree
+* Sparse checkouts::         Sparse checkouts
+* Bundle::                   Bundle
+* Common Commands::          Common Commands
+* Wip Modes::                Wip Modes
+* Commands for Buffers Visiting Files::  Commands for Buffers Visiting Files
+* Minor Mode for Buffers Visiting Blobs::  Minor Mode for Buffers Visiting
+                                             Blobs
 
 
 File: magit.ja.info,  Node: Tagging,  Next: Notes,  Up: Miscellaneous
@@ -7433,8 +7471,8 @@ File: magit.ja.info,  Node: Submodules,  Next: Subtree,  Prev: Notes,  Up: Misce
 
 * Menu:
 
-* Listing Submodules::
-* submodule用トランジェントコマンド::
+* Listing Submodules::       Listing Submodules
+* submodule用トランジェントコマンド::  submodule用トランジェントコマンド
 
 
 File: magit.ja.info,  Node: Listing Submodules,  Next: submodule用トランジェントコマンド,  Up: Submodules
@@ -7869,8 +7907,8 @@ Magitがwip refsに変更をコミットしたかどうかわからない場合�
 
 * Menu:
 
-* Wip Graph::
-* Legacy Wip Modes::
+* Wip Graph::                Wip Graph
+* Legacy Wip Modes::         Legacy Wip Modes
 
 
 File: magit.ja.info,  Node: Wip Graph,  Next: Legacy Wip Modes,  Up: Wip Modes
@@ -8183,8 +8221,8 @@ GitとEmacsはどちらも高度にカスタマイズ可能です。MagitはGit�
 
 * Menu:
 
-* Per-Repository Configuration::
-* 基本設定::
+* Per-Repository Configuration::  Per-Repository Configuration
+* 基本設定::             基本設定
 
 
 File: magit.ja.info,  Node: Per-Repository Configuration,  Next: 基本設定,  Up: Customizing
@@ -8258,9 +8296,9 @@ File: magit.ja.info,  Node: 基本設定,  Prev: Per-Repository Configuration,  
 
 * Menu:
 
-* Safety::
-* Performance::
-* Default Bindings::
+* Safety::                   Safety
+* Performance::              Performance
+* Default Bindings::         Default Bindings
 
 
 File: magit.ja.info,  Node: Safety,  Next: Performance,  Up: 基本設定
@@ -8361,8 +8399,8 @@ Configuration::)。たとえば、非常に多くのタグがあるリポジト�
 
 * Menu:
 
-* Microsoft Windows Performance::
-* MacOS Performance::
+* Microsoft Windows Performance::  Microsoft Windows Performance
+* MacOS Performance::        MacOS Performance
 
 Log Performance
 ...............
@@ -8570,10 +8608,10 @@ Magitで使用される低レベルの機能のいくつかは、個別の ラ�
 
 * Menu:
 
-* Calling Git::
-* Section Plumbing::
-* Refreshing Buffers::
-* 慣習::
+* Calling Git::              Calling Git
+* Section Plumbing::         Section Plumbing
+* Refreshing Buffers::       Refreshing Buffers
+* 慣習::                   慣習
 
 
 File: magit.ja.info,  Node: Calling Git,  Next: Section Plumbing,  Up: 配管コマンド(Plumbing)
@@ -8606,8 +8644,8 @@ Magitは、Gitを呼び出すための多くの特殊な関数を提供します
 
 * Menu:
 
-* Getting a Value from Git::
-* Calling Git for Effect::
+* Getting a Value from Git::  Getting a Value from Git
+* Calling Git for Effect::   Calling Git for Effect
 
 
 File: magit.ja.info,  Node: Getting a Value from Git,  Next: Calling Git for Effect,  Up: Calling Git
@@ -8830,9 +8868,9 @@ File: magit.ja.info,  Node: Section Plumbing,  Next: Refreshing Buffers,  Prev: 
 
 * Menu:
 
-* Creating Sections::
-* Section Selection::
-* Matching Sections::
+* Creating Sections::        Creating Sections
+* Section Selection::        Section Selection
+* Matching Sections::        Matching Sections
 
 
 File: magit.ja.info,  Node: Creating Sections,  Next: Section Selection,  Up: Section Plumbing
@@ -8873,11 +8911,11 @@ File: magit.ja.info,  Node: Creating Sections,  Next: Section Selection,  Up: Se
      に設定され、BODYが評価された後、その‘end’が‘point’の新しい値に設定
      されます。 BODYは、‘point’を前進させる責任があります。
 
-     セクションが空であることがBODY内で判明した場合は、
-     ‘magit-cancel-section’を使用して、部分的に挿入されたセクションのす
-     べてのトレースを中止および削除できます。これは、Gitの出力を洗浄して
-     セクションを作成し、Gitが今回は実際には何も出力しなかった場合に発生
-     する可能性があります。
+     If it turns out inside BODY that the section is empty, then
+     ‘magit-cancel-section’ can be used to abort and remove all traces
+     of the partially inserted section.  This can happen when creating a
+     section by washing Git’s output and Git didn’t actually output
+     anything this time around.
 
  -- Function: magit-insert-heading &rest args
      現在挿入されているセクションの見出しを挿入します。
@@ -8998,17 +9036,17 @@ File: magit.ja.info,  Node: Matching Sections,  Prev: Section Selection,  Up: Se
           セクションのクラスがCLASSまたはそのサブクラスと同じである場合
           に一致します。親セクションのクラスに関係なくです。
 
-     各CLASSは、‘magit-section’から派生したクラスを識別するクラスシンボ
-     ルである必要があります。下位互換性のために、CLASSは「タイプシンボル
-     」にすることもできます。‘type’スロットの値が‘eq’の場合、セクション
-     はそのようなシンボルに一致します。タイプシンボルの
-     ‘magit--section-type-alist’にエントリがある場合、そのクラスがその
-     alistのタイプに対応するクラスのサブクラスであれば、セクションもその
-     タイプに一致します。
+     Each CLASS should be a class symbol, identifying a class that
+     derives from ‘magit-section’.  For backward compatibility CLASS can
+     also be a "type symbol".  A section matches such a symbol if the
+     value of its ‘type’ slot is ‘eq’.  If a type symbol has an entry in
+     ‘magit--section-type-alist’, then a section also matches that type
+     if its class is a subclass of the class that corresponds to the
+     type as per that alist.
 
-     注意: もちろん正確にしたい場合を除いて、あなたは
-     ‘magit-describe-section-briefly’によって出力される完全なセクション
-     系統を指定する必要はないことに注意してください。
+     Note that it is not necessary to specify the complete section
+     lineage as printed by ‘magit-describe-section-briefly’, unless of
+     course you want to be that precise.
 
  -- Function: magit-section-value-if condition &optional section
      ポイントのセクションがCONDITIONと一致する場合は、その値を返します。
@@ -9017,8 +9055,7 @@ File: magit.ja.info,  Node: Matching Sections,  Prev: Section Selection,  Up: Se
      かをテストします。ポイントにセクションがなく、SECTIONがnilの場合は
      、nilを返します。 セクションが一致しない場合は、nilを返します。
 
-     CONDITIONが取ることができる形式については、‘magit-section-match’を
-     参照してください。
+     See ‘magit-section-match’ for the forms CONDITION can take.
 
  -- Function: magit-section-case &rest clauses
      ポイントのセクションのタイプに関する条項(clauses)から選択します。
@@ -9158,7 +9195,7 @@ File: magit.ja.info,  Node: 慣習,  Prev: Refreshing Buffers,  Up: 配管コマ
 
 * Menu:
 
-* Theming Faces::
+* Theming Faces::            Theming Faces
 
 
 File: magit.ja.info,  Node: Theming Faces,  Up: 慣習
@@ -9304,8 +9341,8 @@ Appendix A FAQ
 
 * Menu:
 
-* FAQ - How to ...?::
-* FAQ - Issues and Errors::
+* FAQ - How to ...?::    FAQ - How to ...?
+* FAQ - Issues and Errors::  FAQ - Issues and Errors
 
 
 File: magit.ja.info,  Node: FAQ - How to ...?,  Next: FAQ - Issues and Errors,  Up: FAQ
@@ -9315,12 +9352,15 @@ A.1 FAQ - How to ...?
 
 * Menu:
 
-* Magitの発音は？::
-* How to show git's output?::
-* How to install the gitman info manual?::
-* How to show diffs for gpg-encrypted files?::
-* How does branching and pushing work?::
-* VCを無効にする必要がありますか？::
+* Magitの発音は？::     Magitの発音は？
+* How to show git's output?::  How to show git’s output?
+* How to install the gitman info manual?::  How to install the gitman info
+                                              manual?
+* How to show diffs for gpg-encrypted files?::  How to show diffs for
+                                                  gpg-encrypted files?
+* How does branching and pushing work?::  How does branching and pushing
+                                            work?
+* VCを無効にする必要がありますか？::  VCを無効にする必要がありますか？
 
 
 File: magit.ja.info,  Node: Magitの発音は？,  Next: How to show git's output?,  Up: FAQ - How to ...?
@@ -9429,20 +9469,37 @@ A.2 FAQ - Issues and Errors
 
 * Menu:
 
-* Magit is slow::
-* I changed several thousand files at once and now Magit is unusable::
-* コミットに問題があります::
-* MS WindowsではMagitでpushできません::
-* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.
-* ファイルを展開してdiffを表示するとファイルが消えます::
-* COMMIT_EDITMSGバッファのpointが間違っています::
-* モード行の情報が常に最新ではない::
-* 同じ名前を共有するブランチとタグは何かを壊します::
-* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::
-* コマンドラインからコミットする場合、git-commit-modeは使用されません::
-* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::
-* MS-WindowsからEmacsのTrampモードを使用するとステージできません::
-* 私はポップアップのデフォルトを保存できなくなりました::
+* Magit is slow::            Magit is slow
+* I changed several thousand files at once and now Magit is unusable::  I
+                                                                          changed
+                                                                          several
+                                                                          thousand
+                                                                          files
+                                                                          at
+                                                                          once
+                                                                          and
+                                                                          now
+                                                                          Magit
+                                                                          is
+                                                                          unusable
+* コミットに問題があります::  コミットに問題があります
+* MS WindowsではMagitでpushできません::  MS
+                                                   WindowsではMagitでpushできません
+* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.  私は
+                                                                                                                                                                                                                                             macOS
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません:
+                                                                                                                                                                                                                                             私は
+                                                                                                                                                                                                                                             macOS
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません
+* ファイルを展開してdiffを表示するとファイルが消えます::  ファイルを展開してdiffを表示するとファイルが消えます
+* COMMIT_EDITMSGバッファのpointが間違っています::  ‘COMMIT_EDITMSG’バッファのpointが間違っています
+* モード行の情報が常に最新ではない::  モード行の情報が常に最新ではない
+* 同じ名前を共有するブランチとタグは何かを壊します::  同じ名前を共有するブランチとタグは何かを壊します
+* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::  私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません
+* コマンドラインからコミットする場合、git-commit-modeは使用されません::  コマンドラインからコミットする場合、‘git-commit-mode’は使用されません
+* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::  file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります
+* MS-WindowsからEmacsのTrampモードを使用するとステージできません::  MS-WindowsからEmacsのTrampモードを使用するとステージできません
+* 私はポップアップのデフォルトを保存できなくなりました::  私はポップアップのデフォルトを保存できなくなりました
 
 
 File: magit.ja.info,  Node: Magit is slow,  Next: I changed several thousand files at once and now Magit is unusable,  Up: FAQ - Issues and Errors
@@ -10469,7 +10526,7 @@ Appendix D Function and Command Index
 * magit-diff-refresh:                    Refreshing Diffs.    (line  12)
 * magit-diff-refresh <1>:                Refreshing Diffs.    (line  19)
 * magit-diff-save-default-arguments:     Refreshing Diffs.    (line  28)
-* magit-diff-scope:                      Matching Sections.   (line 108)
+* magit-diff-scope:                      Matching Sections.   (line 107)
 * magit-diff-set-default-arguments:      Refreshing Diffs.    (line  23)
 * magit-diff-show-or-scroll-down:        Log Buffer.          (line  51)
 * magit-diff-show-or-scroll-down <1>:    Blaming.             (line  87)
@@ -10481,7 +10538,7 @@ Appendix D Function and Command Index
 * magit-diff-toggle-refine-hunk:         Refreshing Diffs.    (line  34)
 * magit-diff-trace-definition:           Commands Available in Diffs.
                                                               (line  16)
-* magit-diff-type:                       Matching Sections.   (line  87)
+* magit-diff-type:                       Matching Sections.   (line  86)
 * magit-diff-unstaged:                   Diffing.             (line  54)
 * magit-diff-visit-file:                 Visiting Files and Blobs from a Diff.
                                                               (line   9)
@@ -10828,7 +10885,7 @@ Appendix D Function and Command Index
 * magit-save-window-configuration:       バッファの切り替え.  (line  82)
 * magit-section-backward:                Section Movement.    (line  11)
 * magit-section-backward-siblings:       Section Movement.    (line  18)
-* magit-section-case:                    Matching Sections.   (line  66)
+* magit-section-case:                    Matching Sections.   (line  65)
 * magit-section-cycle:                   Section Visibility.  (line  13)
 * magit-section-cycle-diffs:             Section Visibility.  (line  16)
 * magit-section-cycle-global:            Section Visibility.  (line  19)
@@ -11169,7 +11226,7 @@ Appendix E Variable Index
 * magit-revision-insert-related-refs:    Revision Buffer.     (line   6)
 * magit-revision-show-gravatars:         Revision Buffer.     (line  15)
 * magit-revision-use-hash-sections:      Revision Buffer.     (line  30)
-* magit-root-section:                    Matching Sections.   (line  80)
+* magit-root-section:                    Matching Sections.   (line  79)
 * magit-save-repository-buffers:         Automatic Saving of File-Visiting Buffers.
                                                               (line  12)
 * magit-section-cache-visibility:        Section Visibility.  (line  82)
@@ -11224,175 +11281,175 @@ Appendix E Variable Index
 
 
 Tag Table:
-Node: Top782
-Node: Introduction7498
-Node: Installation14061
-Node: Installing from Melpa14484
-Node: Installing from the Git Repository15843
-Node: Post-Installation Tasks19300
-Node: Getting Started20989
-Node: Interface Concepts28829
-Node: Modes and Buffers29273
-Node: バッファの切り替え31715
-Node: バッファの名付け37936
-Node: Quitting Windows42071
-Node: Automatic Refreshing of Magit Buffers44474
-Node: Automatic Saving of File-Visiting Buffers48366
-Node: Automatic Reverting of File-Visiting Buffers49865
-Node: Risk of Reverting Automatically56478
-Node: Sections59602
-Node: Section Movement60868
-Node: Section Visibility66945
-Node: Section Hooks74955
-Node: Section Types and Values78324
-Node: Section Options80245
-Node: トランジェントコマンド80830
-Node: Transient Arguments and Buffer Variables82717
-Node: Completion Confirmation(確認補完)とSelection(選択範囲)92325
-Node: アクションの確認92844
-Node: 補完と確認103488
-Node: 選択範囲107737
-Node: ハンク内部リージョン111647
-Node: 補完フレームワークのサポート113110
-Node: 追加の補完オプション119169
-Node: Mouse Support119940
-Node: Running Git120737
-Node: Viewing Git Output120993
-Node: Git Process Status124653
-Node: Gitを手動で実行125860
-Node: Git実行ファイル129578
-Node: Global Git Arguments133625
-Node: Inspecting134708
-Node: Status Buffer135974
-Node: Status Sections142451
-Node: Status Header Sections150071
-Node: Status Module Sections153365
-Node: Status Options156765
-Node: Repository List158630
-Node: Logging164507
-Node: Refreshing Logs168610
-Node: Log Buffer170613
-Node: Log Margin176495
-Node: Select from Log180684
-Node: Reflog183559
-Node: Cherries185636
-Node: Diffing188080
-Node: Refreshing Diffs192403
-Node: Commands Available in Diffs197101
-Node: Diff Options200437
-Node: Revision Buffer207440
-Node: Ediffing211727
-Node: References Buffer220446
-Node: References Sections234115
-Node: Bisecting235329
-Node: Visiting Files and Blobs238604
-Node: General-Purpose Visit Commands239206
-Node: Visiting Files and Blobs from a Diff240478
-Node: Blaming245133
-Node: Manipulating253514
-Node: Creating Repository253859
-Node: Cloning Repository254580
-Node: Staging and Unstaging263206
-Node: Staging from File-Visiting Buffers269229
-Node: Applying270975
-Node: Committing274170
-Node: コミット開始274930
-Node: Editing Commit Messages282351
-Node: Using the Revision Stack286009
-Node: Commit Pseudo Headers289896
-Node: Commit Mode and Hooks291632
-Node: Commit Message Conventions295597
-Node: Branching298323
-Node: The Two Remotes298552
-Node: Branch Commands302349
-Node: Branch Git Variables320088
-Node: Auxiliary Branch Commands327061
-Node: Merging328508
-Node: Resolving Conflicts333998
-Node: Rebasing340944
-Node: Editing Rebase Sequences347798
-Node: Information About In-Progress Rebase353425
-Ref: Information About In-Progress Rebase-Footnote-1364903
-Node: Cherry Picking365664
-Node: Reverting371782
-Node: Resetting374038
-Node: Stashing376729
-Node: Transferring383488
-Node: Remotes383713
-Node: Remote Commands383868
-Node: Remote Git Variables389429
-Node: Fetching391130
-Node: Pulling394921
-Node: Pushing396567
-Node: Plain Patches402825
-Node: Maildir Patches405153
-Node: Miscellaneous407379
-Node: Tagging407728
-Node: Notes410518
-Node: Submodules413705
-Node: Listing Submodules413970
-Node: submodule用トランジェントコマンド416610
-Node: Subtree420304
-Node: Worktree423530
-Node: Sparse checkouts425060
-Node: Bundle428982
-Node: Common Commands429565
-Node: Wip Modes432776
-Node: Wip Graph439412
-Node: Legacy Wip Modes442296
-Node: Commands for Buffers Visiting Files445865
-Node: Minor Mode for Buffers Visiting Blobs453821
-Node: Customizing454834
-Node: Per-Repository Configuration456784
-Node: 基本設定459477
-Node: Safety459861
-Node: Performance462279
-Ref: Log Performance466533
-Ref: Diff Performance468292
-Ref: Refs Buffer Performance470005
-Ref: Committing Performance470791
-Node: Microsoft Windows Performance471939
-Node: MacOS Performance473443
-Ref: MacOS Performance-Footnote-1474294
-Node: Default Bindings474433
-Node: 配管コマンド(Plumbing)477378
-Node: Calling Git478493
-Node: Getting a Value from Git480454
-Node: Calling Git for Effect485223
-Node: Section Plumbing493278
-Node: Creating Sections493529
-Node: Section Selection499019
-Node: Matching Sections501215
-Node: Refreshing Buffers508982
-Node: 慣習512948
-Node: Theming Faces513159
-Node: FAQ523827
-Node: FAQ - How to ...?524332
-Node: Magitの発音は？524716
-Node: How to show git's output?525749
-Node: How to install the gitman info manual?526777
-Node: How to show diffs for gpg-encrypted files?528052
-Node: How does branching and pushing work?528755
-Node: VCを無効にする必要がありますか？529137
-Node: FAQ - Issues and Errors529997
-Node: Magit is slow531330
-Node: I changed several thousand files at once and now Magit is unusable531652
-Node: コミットに問題があります532703
-Node: MS WindowsではMagitでpushできません533241
-Node: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません533945
-Node: ファイルを展開してdiffを表示するとファイルが消えます535154
-Node: COMMIT_EDITMSGバッファのpointが間違っています535940
-Node: モード行の情報が常に最新ではない537323
-Node: 同じ名前を共有するブランチとタグは何かを壊します538530
-Node: 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません539683
-Node: コマンドラインからコミットする場合、git-commit-modeは使用されません540821
-Node: file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります543878
-Node: MS-WindowsからEmacsのTrampモードを使用するとステージできません545101
-Node: 私はポップアップのデフォルトを保存できなくなりました546280
-Node: Debugging Tools547687
-Node: Keystroke Index551975
-Node: Function and Command Index586607
-Node: Variable Index639185
+Node: Top790
+Node: Introduction15407
+Node: Installation21970
+Node: Installing from Melpa22479
+Node: Installing from the Git Repository23838
+Node: Post-Installation Tasks27295
+Node: Getting Started28984
+Node: Interface Concepts36824
+Node: Modes and Buffers37905
+Node: バッファの切り替え40701
+Node: バッファの名付け46922
+Node: Quitting Windows51057
+Node: Automatic Refreshing of Magit Buffers53460
+Node: Automatic Saving of File-Visiting Buffers57352
+Node: Automatic Reverting of File-Visiting Buffers58851
+Node: Risk of Reverting Automatically65497
+Node: Sections68621
+Node: Section Movement70013
+Node: Section Visibility76090
+Node: Section Hooks84100
+Node: Section Types and Values87469
+Node: Section Options89390
+Node: トランジェントコマンド89975
+Node: Transient Arguments and Buffer Variables91862
+Node: Completion Confirmation(確認補完)とSelection(選択範囲)101470
+Node: アクションの確認102173
+Node: 補完と確認112817
+Node: 選択範囲117066
+Node: ハンク内部リージョン120976
+Node: 補完フレームワークのサポート122439
+Node: 追加の補完オプション128498
+Node: Mouse Support129269
+Node: Running Git130066
+Node: Viewing Git Output130447
+Node: Git Process Status134107
+Node: Gitを手動で実行135314
+Node: Git実行ファイル139032
+Node: Global Git Arguments143079
+Node: Inspecting144162
+Node: Status Buffer145654
+Node: Status Sections152231
+Node: Status Header Sections159851
+Node: Status Module Sections163145
+Node: Status Options166545
+Node: Repository List168410
+Node: Logging174287
+Node: Refreshing Logs178540
+Node: Log Buffer180543
+Node: Log Margin186425
+Node: Select from Log190614
+Node: Reflog193489
+Node: Cherries195566
+Node: Diffing198010
+Node: Refreshing Diffs202437
+Node: Commands Available in Diffs207135
+Node: Diff Options210471
+Node: Revision Buffer217474
+Node: Ediffing221761
+Node: References Buffer230480
+Node: References Sections244174
+Node: Bisecting245388
+Node: Visiting Files and Blobs248663
+Node: General-Purpose Visit Commands249379
+Node: Visiting Files and Blobs from a Diff250651
+Node: Blaming255306
+Node: Manipulating263687
+Node: Creating Repository264332
+Node: Cloning Repository265053
+Node: Staging and Unstaging273679
+Node: Staging from File-Visiting Buffers279738
+Node: Applying281484
+Node: Committing284679
+Node: コミット開始285489
+Node: Editing Commit Messages292910
+Node: Using the Revision Stack296672
+Node: Commit Pseudo Headers300559
+Node: Commit Mode and Hooks302295
+Node: Commit Message Conventions306260
+Node: Branching308986
+Node: The Two Remotes309317
+Node: Branch Commands313114
+Node: Branch Git Variables330853
+Node: Auxiliary Branch Commands337826
+Node: Merging339273
+Node: Resolving Conflicts344763
+Node: Rebasing351709
+Node: Editing Rebase Sequences358671
+Node: Information About In-Progress Rebase364298
+Ref: Information About In-Progress Rebase-Footnote-1375776
+Node: Cherry Picking376537
+Node: Reverting382680
+Node: Resetting384936
+Node: Stashing387627
+Node: Transferring394386
+Node: Remotes394761
+Node: Remote Commands394966
+Node: Remote Git Variables400527
+Node: Fetching402228
+Node: Pulling406019
+Node: Pushing407665
+Node: Plain Patches413923
+Node: Maildir Patches416251
+Node: Miscellaneous418477
+Node: Tagging419172
+Node: Notes421962
+Node: Submodules425149
+Node: Listing Submodules425486
+Node: submodule用トランジェントコマンド428126
+Node: Subtree431820
+Node: Worktree435046
+Node: Sparse checkouts436576
+Node: Bundle440498
+Node: Common Commands441081
+Node: Wip Modes444292
+Node: Wip Graph450978
+Node: Legacy Wip Modes453862
+Node: Commands for Buffers Visiting Files457431
+Node: Minor Mode for Buffers Visiting Blobs465387
+Node: Customizing466400
+Node: Per-Repository Configuration468405
+Node: 基本設定471098
+Node: Safety471557
+Node: Performance473975
+Ref: Log Performance478285
+Ref: Diff Performance480044
+Ref: Refs Buffer Performance481757
+Ref: Committing Performance482543
+Node: Microsoft Windows Performance483691
+Node: MacOS Performance485195
+Ref: MacOS Performance-Footnote-1486046
+Node: Default Bindings486185
+Node: 配管コマンド(Plumbing)489130
+Node: Calling Git490345
+Node: Getting a Value from Git492357
+Node: Calling Git for Effect497126
+Node: Section Plumbing505181
+Node: Creating Sections505507
+Node: Section Selection510888
+Node: Matching Sections513084
+Node: Refreshing Buffers520571
+Node: 慣習524537
+Node: Theming Faces524773
+Node: FAQ535441
+Node: FAQ - How to ...?535992
+Node: Magitの発音は？536741
+Node: How to show git's output?537774
+Node: How to install the gitman info manual?538802
+Node: How to show diffs for gpg-encrypted files?540077
+Node: How does branching and pushing work?540780
+Node: VCを無効にする必要がありますか？541162
+Node: FAQ - Issues and Errors542022
+Node: Magit is slow546561
+Node: I changed several thousand files at once and now Magit is unusable546883
+Node: コミットに問題があります547934
+Node: MS WindowsではMagitでpushできません548472
+Node: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません549176
+Node: ファイルを展開してdiffを表示するとファイルが消えます550385
+Node: COMMIT_EDITMSGバッファのpointが間違っています551171
+Node: モード行の情報が常に最新ではない552554
+Node: 同じ名前を共有するブランチとタグは何かを壊します553761
+Node: 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません554914
+Node: コマンドラインからコミットする場合、git-commit-modeは使用されません556052
+Node: file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります559109
+Node: MS-WindowsからEmacsのTrampモードを使用するとステージできません560332
+Node: 私はポップアップのデフォルトを保存できなくなりました561511
+Node: Debugging Tools562918
+Node: Keystroke Index567206
+Node: Function and Command Index601838
+Node: Variable Index654416
 
 End Tag Table
 

--- a/docs/docs-ja/magit.ja.info
+++ b/docs/docs-ja/magit.ja.info
@@ -8911,11 +8911,11 @@ File: magit.ja.info,  Node: Creating Sections,  Next: Section Selection,  Up: Se
      に設定され、BODYが評価された後、その‘end’が‘point’の新しい値に設定
      されます。 BODYは、‘point’を前進させる責任があります。
 
-     If it turns out inside BODY that the section is empty, then
-     ‘magit-cancel-section’ can be used to abort and remove all traces
-     of the partially inserted section.  This can happen when creating a
-     section by washing Git’s output and Git didn’t actually output
-     anything this time around.
+     セクションが空であることがBODY内で判明した場合は、
+     ‘magit-cancel-section’を使用して、部分的に挿入されたセクションのす
+     べてのトレースを中止して削除できます。これは、Gitの出力を洗浄
+     (wash)してセクションを作成し、Gitが今回は実際には何も出力しなかった
+     場合に発生する可能性があります。
 
  -- Function: magit-insert-heading &rest args
      現在挿入されているセクションの見出しを挿入します。
@@ -9036,17 +9036,17 @@ File: magit.ja.info,  Node: Matching Sections,  Prev: Section Selection,  Up: Se
           セクションのクラスがCLASSまたはそのサブクラスと同じである場合
           に一致します。親セクションのクラスに関係なくです。
 
-     Each CLASS should be a class symbol, identifying a class that
-     derives from ‘magit-section’.  For backward compatibility CLASS can
-     also be a "type symbol".  A section matches such a symbol if the
-     value of its ‘type’ slot is ‘eq’.  If a type symbol has an entry in
-     ‘magit--section-type-alist’, then a section also matches that type
-     if its class is a subclass of the class that corresponds to the
-     type as per that alist.
+     各CLASSは、‘magit-section’から派生したクラスを識別するクラスシンボ
+     ルである必要があります。下位互換性のために、CLASSは「タイプシンボル
+     」にすることもできます。‘type’スロットの値が‘eq’の場合、セクション
+     はそのようなシンボルに一致します。タイプシンボルの
+     ‘magit--section-type-alist’にエントリがある場合、そのクラスがその
+     alistのタイプに対応するクラスのサブクラスであれば、セクションもその
+     タイプに一致します。
 
-     Note that it is not necessary to specify the complete section
-     lineage as printed by ‘magit-describe-section-briefly’, unless of
-     course you want to be that precise.
+     注意: もちろん、正確にしたい場合を除いて、
+     ‘magit-describe-section-briefly’によって出力される完全なセクション
+     系統を指定する必要はないことに注意してください。
 
  -- Function: magit-section-value-if condition &optional section
      ポイントのセクションがCONDITIONと一致する場合は、その値を返します。
@@ -9055,7 +9055,8 @@ File: magit.ja.info,  Node: Matching Sections,  Prev: Section Selection,  Up: Se
      かをテストします。ポイントにセクションがなく、SECTIONがnilの場合は
      、nilを返します。 セクションが一致しない場合は、nilを返します。
 
-     See ‘magit-section-match’ for the forms CONDITION can take.
+     CONDITIONが取ることができる形式については、‘magit-section-match’を
+     参照してください。
 
  -- Function: magit-section-case &rest clauses
      ポイントのセクションのタイプに関する条項(clauses)から選択します。
@@ -10526,7 +10527,7 @@ Appendix D Function and Command Index
 * magit-diff-refresh:                    Refreshing Diffs.    (line  12)
 * magit-diff-refresh <1>:                Refreshing Diffs.    (line  19)
 * magit-diff-save-default-arguments:     Refreshing Diffs.    (line  28)
-* magit-diff-scope:                      Matching Sections.   (line 107)
+* magit-diff-scope:                      Matching Sections.   (line 108)
 * magit-diff-set-default-arguments:      Refreshing Diffs.    (line  23)
 * magit-diff-show-or-scroll-down:        Log Buffer.          (line  51)
 * magit-diff-show-or-scroll-down <1>:    Blaming.             (line  87)
@@ -10538,7 +10539,7 @@ Appendix D Function and Command Index
 * magit-diff-toggle-refine-hunk:         Refreshing Diffs.    (line  34)
 * magit-diff-trace-definition:           Commands Available in Diffs.
                                                               (line  16)
-* magit-diff-type:                       Matching Sections.   (line  86)
+* magit-diff-type:                       Matching Sections.   (line  87)
 * magit-diff-unstaged:                   Diffing.             (line  54)
 * magit-diff-visit-file:                 Visiting Files and Blobs from a Diff.
                                                               (line   9)
@@ -10885,7 +10886,7 @@ Appendix D Function and Command Index
 * magit-save-window-configuration:       バッファの切り替え.  (line  82)
 * magit-section-backward:                Section Movement.    (line  11)
 * magit-section-backward-siblings:       Section Movement.    (line  18)
-* magit-section-case:                    Matching Sections.   (line  65)
+* magit-section-case:                    Matching Sections.   (line  66)
 * magit-section-cycle:                   Section Visibility.  (line  13)
 * magit-section-cycle-diffs:             Section Visibility.  (line  16)
 * magit-section-cycle-global:            Section Visibility.  (line  19)
@@ -11226,7 +11227,7 @@ Appendix E Variable Index
 * magit-revision-insert-related-refs:    Revision Buffer.     (line   6)
 * magit-revision-show-gravatars:         Revision Buffer.     (line  15)
 * magit-revision-use-hash-sections:      Revision Buffer.     (line  30)
-* magit-root-section:                    Matching Sections.   (line  79)
+* magit-root-section:                    Matching Sections.   (line  80)
 * magit-save-repository-buffers:         Automatic Saving of File-Visiting Buffers.
                                                               (line  12)
 * magit-section-cache-visibility:        Section Visibility.  (line  82)
@@ -11418,38 +11419,38 @@ Node: Getting a Value from Git492357
 Node: Calling Git for Effect497126
 Node: Section Plumbing505181
 Node: Creating Sections505507
-Node: Section Selection510888
-Node: Matching Sections513084
-Node: Refreshing Buffers520571
-Node: 慣習524537
-Node: Theming Faces524773
-Node: FAQ535441
-Node: FAQ - How to ...?535992
-Node: Magitの発音は？536741
-Node: How to show git's output?537774
-Node: How to install the gitman info manual?538802
-Node: How to show diffs for gpg-encrypted files?540077
-Node: How does branching and pushing work?540780
-Node: VCを無効にする必要がありますか？541162
-Node: FAQ - Issues and Errors542022
-Node: Magit is slow546561
-Node: I changed several thousand files at once and now Magit is unusable546883
-Node: コミットに問題があります547934
-Node: MS WindowsではMagitでpushできません548472
-Node: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません549176
-Node: ファイルを展開してdiffを表示するとファイルが消えます550385
-Node: COMMIT_EDITMSGバッファのpointが間違っています551171
-Node: モード行の情報が常に最新ではない552554
-Node: 同じ名前を共有するブランチとタグは何かを壊します553761
-Node: 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません554914
-Node: コマンドラインからコミットする場合、git-commit-modeは使用されません556052
-Node: file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります559109
-Node: MS-WindowsからEmacsのTrampモードを使用するとステージできません560332
-Node: 私はポップアップのデフォルトを保存できなくなりました561511
-Node: Debugging Tools562918
-Node: Keystroke Index567206
-Node: Function and Command Index601838
-Node: Variable Index654416
+Node: Section Selection511000
+Node: Matching Sections513196
+Node: Refreshing Buffers520954
+Node: 慣習524920
+Node: Theming Faces525156
+Node: FAQ535824
+Node: FAQ - How to ...?536375
+Node: Magitの発音は？537124
+Node: How to show git's output?538157
+Node: How to install the gitman info manual?539185
+Node: How to show diffs for gpg-encrypted files?540460
+Node: How does branching and pushing work?541163
+Node: VCを無効にする必要がありますか？541545
+Node: FAQ - Issues and Errors542405
+Node: Magit is slow546944
+Node: I changed several thousand files at once and now Magit is unusable547266
+Node: コミットに問題があります548317
+Node: MS WindowsではMagitでpushできません548855
+Node: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません549559
+Node: ファイルを展開してdiffを表示するとファイルが消えます550768
+Node: COMMIT_EDITMSGバッファのpointが間違っています551554
+Node: モード行の情報が常に最新ではない552937
+Node: 同じ名前を共有するブランチとタグは何かを壊します554144
+Node: 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません555297
+Node: コマンドラインからコミットする場合、git-commit-modeは使用されません556435
+Node: file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります559492
+Node: MS-WindowsからEmacsのTrampモードを使用するとステージできません560715
+Node: 私はポップアップのデフォルトを保存できなくなりました561894
+Node: Debugging Tools563301
+Node: Keystroke Index567589
+Node: Function and Command Index602221
+Node: Variable Index654799
 
 End Tag Table
 

--- a/docs/docs-ja/magit.ja.texi
+++ b/docs/docs-ja/magit.ja.texi
@@ -4,6 +4,7 @@
 @c This file was generated with po4a. Translate the source file.
 @c
 @c ===========================================================================
+
 @c %**start of header
 @setfilename magit.info
 @settitle Magit User Manual
@@ -57,21 +58,21 @@ This manual is for Magit version 3.3.0-git.
 @end ifnottex
 
 @menu
-* Introduction::
-* Installation::
-* Getting Started::
-* Interface Concepts::
-* Inspecting::
-* Manipulating::
-* Transferring::
-* Miscellaneous::
-* Customizing::
-* 配管コマンド(Plumbing)::
-* FAQ::
-* Debugging Tools::
-* Keystroke Index::
-* Function and Command Index::
-* Variable Index::           
+* Introduction::             Introduction
+* Installation::             Installation
+* Getting Started::          Getting Started
+* Interface Concepts::       Interface Concepts
+* Inspecting::               Inspecting
+* Manipulating::             Manipulating
+* Transferring::             Transferring
+* Miscellaneous::            Miscellaneous
+* Customizing::              Customizing
+* 配管コマンド(Plumbing)::  配管コマンド(Plumbing)
+* FAQ::                      FAQ
+* Debugging Tools::          Debugging Tools
+* Keystroke Index::          Keystroke Index
+* Function and Command Index::  Function and Command Index
+* Variable Index::           Variable Index
 
 @detailmenu
 --- The Detailed Node Listing ---
@@ -82,32 +83,38 @@ Installation
 
 
 
-* Installing from Melpa::
-* Installing from the Git Repository::
-* Post-Installation Tasks::  
+* Installing from Melpa::    Installing from Melpa
+* Installing from the Git Repository::  Installing from the Git Repository
+* Post-Installation Tasks::  Post-Installation Tasks
 
 Interface Concepts
 
 
 
-* Modes and Buffers::
-* Sections::
-* トランジェントコマンド::
-* Transient Arguments and Buffer Variables::
-* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).  
-* Mouse Support::
-* Running Git::              
+* Modes and Buffers::        Modes and Buffers
+* Sections::                 Sections
+* トランジェントコマンド::  トランジェントコマンド
+* Transient Arguments and Buffer Variables::  Transient Arguments and Buffer 
+                                                Variables
+* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).  Completion(補完)とConfirmation(確認)とSelection(選択範囲): 
+                                                                                                                                           Completion 
+                                                                                                                                           Confirmation(確認補完)とSelection(選択範囲)
+* Mouse Support::            Mouse Support
+* Running Git::              Running Git
 
 Modes and Buffers
 
 
 
-* バッファの切り替え::
-* バッファの名付け::
-* Quitting Windows::
-* Automatic Refreshing of Magit Buffers::
-* Automatic Saving of File-Visiting Buffers::
-* Automatic Reverting of File-Visiting Buffers::  
+* バッファの切り替え::  バッファの切り替え
+* バッファの名付け::  バッファの名付け
+* Quitting Windows::         Quitting Windows
+* Automatic Refreshing of Magit Buffers::  Automatic Refreshing of Magit 
+                                             Buffers
+* Automatic Saving of File-Visiting Buffers::  Automatic Saving of 
+                                                 File-Visiting Buffers
+* Automatic Reverting of File-Visiting Buffers::  Automatic Reverting of 
+                                                    File-Visiting Buffers
 
 
 
@@ -115,11 +122,11 @@ Sections
 
 
 
-* Section Movement::
-* Section Visibility::
-* Section Hooks::
-* Section Types and Values::
-* Section Options::          
+* Section Movement::         Section Movement
+* Section Visibility::       Section Visibility
+* Section Hooks::            Section Hooks
+* Section Types and Values::  Section Types and Values
+* Section Options::          Section Options
 
 
 
@@ -127,12 +134,12 @@ Completion(補完)とConfirmation(確認)とSelection(選択範囲)
 
 
 
-* アクションの確認::
-* 補完と確認::
-* 選択範囲::
-* ハンク内部リージョン::
-* 補完フレームワークのサポート::
-* 追加の補完オプション::  
+* アクションの確認::  アクションの確認
+* 補完と確認::          補完と確認
+* 選択範囲::             選択範囲
+* ハンク内部リージョン::  ハンク内部リージョン
+* 補完フレームワークのサポート::  補完フレームワークのサポート
+* 追加の補完オプション::  追加の補完オプション
 
 
 
@@ -140,11 +147,11 @@ Running Git
 
 
 
-* Viewing Git Output::
-* Git Process Status::
-* Gitを手動で実行::
-* Git実行ファイル::
-* Global Git Arguments::     
+* Viewing Git Output::       Viewing Git Output
+* Git Process Status::       Git Process Status
+* Gitを手動で実行::    Gitを手動で実行
+* Git実行ファイル::    Git実行ファイル
+* Global Git Arguments::     Global Git Arguments
 
 
 
@@ -152,24 +159,24 @@ Inspecting
 
 
 
-* Status Buffer::
-* Repository List::
-* Logging::
-* Diffing::
-* Ediffing::
-* References Buffer::
-* Bisecting::
-* Visiting Files and Blobs::
-* Blaming::                  
+* Status Buffer::            Status Buffer
+* Repository List::          Repository List
+* Logging::                  Logging
+* Diffing::                  Diffing
+* Ediffing::                 Ediffing
+* References Buffer::        References Buffer
+* Bisecting::                Bisecting
+* Visiting Files and Blobs::  Visiting Files and Blobs
+* Blaming::                  Blaming
 
 Status Buffer
 
 
 
-* Status Sections::
-* Status Header Sections::
-* Status Module Sections::
-* Status Options::           
+* Status Sections::          Status Sections
+* Status Header Sections::   Status Header Sections
+* Status Module Sections::   Status Module Sections
+* Status Options::           Status Options
 
 
 
@@ -177,12 +184,12 @@ Logging
 
 
 
-* Refreshing Logs::
-* Log Buffer::
-* Log Margin::
-* Select from Log::
-* Reflog::
-* Cherries::                 
+* Refreshing Logs::          Refreshing Logs
+* Log Buffer::               Log Buffer
+* Log Margin::               Log Margin
+* Select from Log::          Select from Log
+* Reflog::                   Reflog
+* Cherries::                 Cherries
 
 
 
@@ -190,10 +197,10 @@ Diffing
 
 
 
-* Refreshing Diffs::
-* Commands Available in Diffs::
-* Diff Options::
-* Revision Buffer::          
+* Refreshing Diffs::         Refreshing Diffs
+* Commands Available in Diffs::  Commands Available in Diffs
+* Diff Options::             Diff Options
+* Revision Buffer::          Revision Buffer
 
 
 
@@ -201,7 +208,7 @@ References Buffer
 
 
 
-* References Sections::      
+* References Sections::      References Sections
 
 
 
@@ -209,8 +216,9 @@ Visiting Files and Blobs
 
 
 
-* General-Purpose Visit Commands::
-* Visiting Files and Blobs from a Diff::  
+* General-Purpose Visit Commands::  General-Purpose Visit Commands
+* Visiting Files and Blobs from a Diff::  Visiting Files and Blobs from a 
+                                            Diff
 
 
 
@@ -218,24 +226,24 @@ Manipulating
 
 
 
-* Creating Repository::
-* Cloning Repository::
-* Staging and Unstaging::
-* Applying::
-* Committing::
-* Branching::
-* Merging::
-* Resolving Conflicts::
-* Rebasing::
-* Cherry Picking::
-* Resetting::
-* Stashing::                 
+* Creating Repository::      Creating Repository
+* Cloning Repository::       Cloning Repository
+* Staging and Unstaging::    Staging and Unstaging
+* Applying::                 Applying
+* Committing::               Committing
+* Branching::                Branching
+* Merging::                  Merging
+* Resolving Conflicts::      Resolving Conflicts
+* Rebasing::                 Rebasing
+* Cherry Picking::           Cherry Picking
+* Resetting::                Resetting
+* Stashing::                 Stashing
 
 Staging and Unstaging
 
 
 
-* Staging from File-Visiting Buffers::  
+* Staging from File-Visiting Buffers::  Staging from File-Visiting Buffers
 
 
 
@@ -243,8 +251,8 @@ Committing
 
 
 
-* コミット開始::
-* Editing Commit Messages::  
+* コミット開始::       コミット開始
+* Editing Commit Messages::  Editing Commit Messages
 
 
 
@@ -252,10 +260,10 @@ Branching
 
 
 
-* The Two Remotes::
-* Branch Commands::
-* Branch Git Variables::
-* Auxiliary Branch Commands::  
+* The Two Remotes::          The Two Remotes
+* Branch Commands::          Branch Commands
+* Branch Git Variables::     Branch Git Variables
+* Auxiliary Branch Commands::  Auxiliary Branch Commands
 
 
 
@@ -263,8 +271,9 @@ Rebasing
 
 
 
-* Editing Rebase Sequences::
-* Information About In-Progress Rebase::  
+* Editing Rebase Sequences::  Editing Rebase Sequences
+* Information About In-Progress Rebase::  Information About In-Progress 
+                                            Rebase
 
 
 
@@ -272,7 +281,7 @@ Cherry Picking
 
 
 
-* Reverting::                
+* Reverting::                Reverting
 
 
 
@@ -280,19 +289,19 @@ Transferring
 
 
 
-* Remotes::
-* Fetching::
-* Pulling::
-* Pushing::
-* Plain Patches::
-* Maildir Patches::          
+* Remotes::                  Remotes
+* Fetching::                 Fetching
+* Pulling::                  Pulling
+* Pushing::                  Pushing
+* Plain Patches::            Plain Patches
+* Maildir Patches::          Maildir Patches
 
 Remotes
 
 
 
-* Remote Commands::
-* Remote Git Variables::     
+* Remote Commands::          Remote Commands
+* Remote Git Variables::     Remote Git Variables
 
 
 
@@ -300,24 +309,25 @@ Miscellaneous
 
 
 
-* Tagging::
-* Notes::
-* Submodules::
-* Subtree::
-* Worktree::
-* Sparse checkouts::
-* Bundle::
-* Common Commands::
-* Wip Modes::
-* Commands for Buffers Visiting Files::
-* Minor Mode for Buffers Visiting Blobs::  
+* Tagging::                  Tagging
+* Notes::                    Notes
+* Submodules::               Submodules
+* Subtree::                  Subtree
+* Worktree::                 Worktree
+* Sparse checkouts::         Sparse checkouts
+* Bundle::                   Bundle
+* Common Commands::          Common Commands
+* Wip Modes::                Wip Modes
+* Commands for Buffers Visiting Files::  Commands for Buffers Visiting Files
+* Minor Mode for Buffers Visiting Blobs::  Minor Mode for Buffers Visiting 
+                                             Blobs
 
 Submodules
 
 
 
-* Listing Submodules::
-* submodule用トランジェントコマンド::  
+* Listing Submodules::       Listing Submodules
+* submodule用トランジェントコマンド::  submodule用トランジェントコマンド
 
 
 
@@ -325,8 +335,8 @@ Wip Modes
 
 
 
-* Wip Graph::
-* Legacy Wip Modes::         
+* Wip Graph::                Wip Graph
+* Legacy Wip Modes::         Legacy Wip Modes
 
 
 
@@ -334,16 +344,16 @@ Customizing
 
 
 
-* Per-Repository Configuration::
-* 基本設定::             
+* Per-Repository Configuration::  Per-Repository Configuration
+* 基本設定::             基本設定
 
 基本設定
 
 
 
-* Safety::
-* Performance::
-* Default Bindings::         
+* Safety::                   Safety
+* Performance::              Performance
+* Default Bindings::         Default Bindings
 
 
 
@@ -351,17 +361,17 @@ Customizing
 
 
 
-* Calling Git::
-* Section Plumbing::
-* Refreshing Buffers::
-* 慣習::                   
+* Calling Git::              Calling Git
+* Section Plumbing::         Section Plumbing
+* Refreshing Buffers::       Refreshing Buffers
+* 慣習::                   慣習
 
 Calling Git
 
 
 
-* Getting a Value from Git::
-* Calling Git for Effect::   
+* Getting a Value from Git::  Getting a Value from Git
+* Calling Git for Effect::   Calling Git for Effect
 
 
 
@@ -369,9 +379,9 @@ Section Plumbing
 
 
 
-* Creating Sections::
-* Section Selection::
-* Matching Sections::        
+* Creating Sections::        Creating Sections
+* Section Selection::        Section Selection
+* Matching Sections::        Matching Sections
 
 
 
@@ -379,7 +389,7 @@ Section Plumbing
 
 
 
-* Theming Faces::            
+* Theming Faces::            Theming Faces
 
 
 
@@ -387,19 +397,22 @@ FAQ
 
 
 
-* FAQ - How to @dots{}?::
-* FAQ - Issues and Errors::  
+* FAQ - How to @dots{}?::    FAQ - How to @dots{}?
+* FAQ - Issues and Errors::  FAQ - Issues and Errors
 
 FAQ - How to @dots{}?
 
 
 
-* Magitの発音は？::
-* How to show git's output?::
-* How to install the gitman info manual?::
-* How to show diffs for gpg-encrypted files?::
-* How does branching and pushing work?::
-* VCを無効にする必要がありますか？::  
+* Magitの発音は？::     Magitの発音は？
+* How to show git's output?::  How to show git's output?
+* How to install the gitman info manual?::  How to install the gitman info 
+                                              manual?
+* How to show diffs for gpg-encrypted files?::  How to show diffs for 
+                                                  gpg-encrypted files?
+* How does branching and pushing work?::  How does branching and pushing 
+                                            work?
+* VCを無効にする必要がありますか？::  VCを無効にする必要がありますか？
 
 
 
@@ -407,20 +420,37 @@ FAQ - Issues and Errors
 
 
 
-* Magit is slow::
-* I changed several thousand files at once and now Magit is unusable::
-* コミットに問題があります::
-* MS WindowsではMagitでpushできません::
-* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.  
-* ファイルを展開してdiffを表示するとファイルが消えます::
-* @code{COMMIT_EDITMSG}バッファのpointが間違っています::
-* モード行の情報が常に最新ではない::
-* 同じ名前を共有するブランチとタグは何かを壊します::
-* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::
-* コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません::
-* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::
-* MS-WindowsからEmacsのTrampモードを使用するとステージできません::
-* 私はポップアップのデフォルトを保存できなくなりました::  
+* Magit is slow::            Magit is slow
+* I changed several thousand files at once and now Magit is unusable::  I 
+                                                                          changed 
+                                                                          several 
+                                                                          thousand 
+                                                                          files 
+                                                                          at 
+                                                                          once 
+                                                                          and 
+                                                                          now 
+                                                                          Magit 
+                                                                          is 
+                                                                          unusable
+* コミットに問題があります::  コミットに問題があります
+* MS WindowsではMagitでpushできません::  MS 
+                                                   WindowsではMagitでpushできません
+* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.  私は 
+                                                                                                                                                                                                                                             macOS 
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 
+                                                                                                                                                                                                                                             私は 
+                                                                                                                                                                                                                                             macOS 
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません
+* ファイルを展開してdiffを表示するとファイルが消えます::  ファイルを展開してdiffを表示するとファイルが消えます
+* @code{COMMIT_EDITMSG}バッファのpointが間違っています::  @code{COMMIT_EDITMSG}バッファのpointが間違っています
+* モード行の情報が常に最新ではない::  モード行の情報が常に最新ではない
+* 同じ名前を共有するブランチとタグは何かを壊します::  同じ名前を共有するブランチとタグは何かを壊します
+* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::  私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません
+* コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません::  コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません
+* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::  file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります
+* MS-WindowsからEmacsのTrampモードを使用するとステージできません::  MS-WindowsからEmacsのTrampモードを使用するとステージできません
+* 私はポップアップのデフォルトを保存できなくなりました::  私はポップアップのデフォルトを保存できなくなりました
 
 
 
@@ -479,9 +509,9 @@ Magitはラップすることにより、多くの場合、少なくとも次の
 Magitは、Emacsのパッケージマネージャーを使用してインストールすることも、開発リポジトリから手動でインストールすることもできます。
 
 @menu
-* Installing from Melpa::
-* Installing from the Git Repository::
-* Post-Installation Tasks::  
+* Installing from Melpa::    Installing from Melpa
+* Installing from the Git Repository::  Installing from the Git Repository
+* Post-Installation Tasks::  Post-Installation Tasks
 @end menu
 
 @node Installing from Melpa
@@ -683,13 +713,16 @@ Magit は、コンテキストメニューやその他マウスコマンドも�
 @chapter Interface Concepts
 
 @menu
-* Modes and Buffers::
-* Sections::
-* トランジェントコマンド::
-* Transient Arguments and Buffer Variables::
-* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).  
-* Mouse Support::
-* Running Git::              
+* Modes and Buffers::        Modes and Buffers
+* Sections::                 Sections
+* トランジェントコマンド::  トランジェントコマンド
+* Transient Arguments and Buffer Variables::  Transient Arguments and Buffer 
+                                                Variables
+* Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion Confirmation(確認補完)とSelection(選択範囲).  Completion(補完)とConfirmation(確認)とSelection(選択範囲): 
+                                                                                                                                           Completion 
+                                                                                                                                           Confirmation(確認補完)とSelection(選択範囲)
+* Mouse Support::            Mouse Support
+* Running Git::              Running Git
 @end menu
 
 @node Modes and Buffers
@@ -715,12 +748,15 @@ Magitはいくつかのメジャーモードを提供します。
 @end table
 
 @menu
-* バッファの切り替え::
-* バッファの名付け::
-* Quitting Windows::
-* Automatic Refreshing of Magit Buffers::
-* Automatic Saving of File-Visiting Buffers::
-* Automatic Reverting of File-Visiting Buffers::  
+* バッファの切り替え::  バッファの切り替え
+* バッファの名付け::  バッファの名付け
+* Quitting Windows::         Quitting Windows
+* Automatic Refreshing of Magit Buffers::  Automatic Refreshing of Magit 
+                                             Buffers
+* Automatic Saving of File-Visiting Buffers::  Automatic Saving of 
+                                                 File-Visiting Buffers
+* Automatic Reverting of File-Visiting Buffers::  Automatic Reverting of 
+                                                    File-Visiting Buffers
 @end menu
 
 @node バッファの切り替え
@@ -1014,7 +1050,7 @@ Magitがオンにしないバッファで@code{auto-revert-mode}をオンにす�
 @code{auto-revert-}接頭辞が付いたオプションは、@code{auto-revert}という名前のカスタムグループにあります。他のMagit固有のオプションは、@code{magit}グループにあります。
 
 @menu
-* Risk of Reverting Automatically::  
+* Risk of Reverting Automatically::  Risk of Reverting Automatically
 @end menu
 
 @node Risk of Reverting Automatically
@@ -1041,11 +1077,11 @@ Magitバッファはネストされたセクションに編成され、Orgモー
 セクションの値とタイプを利用して、多くのコマンドが現在のセクションで動作します。または、リージョンがアクティブで同じタイプのセクションを選択すると、選択されたすべてのセクションが操作されます。(タイプの違いのみよって動作が異なるだけではなく)特定のセクションタイプに対してのみ意味のあるコマンドは、通常、セクションタイプのキーマップにバインドされます。
 
 @menu
-* Section Movement::
-* Section Visibility::
-* Section Hooks::
-* Section Types and Values::
-* Section Options::          
+* Section Movement::         Section Movement
+* Section Visibility::       Section Visibility
+* Section Hooks::            Section Hooks
+* Section Types and Values::  Section Types and Values
+* Section Options::          Section Options
 @end menu
 
 @node Section Movement
@@ -1441,12 +1477,12 @@ diff用トランジェントプレフィックスコマンドを呼び出すと�
 @section Completion(補完)とConfirmation(確認)とSelection(選択範囲)
 
 @menu
-* アクションの確認::
-* 補完と確認::
-* 選択範囲::
-* ハンク内部リージョン::
-* 補完フレームワークのサポート::
-* 追加の補完オプション::  
+* アクションの確認::  アクションの確認
+* 補完と確認::          補完と確認
+* 選択範囲::             選択範囲
+* ハンク内部リージョン::  ハンク内部リージョン
+* 補完フレームワークのサポート::  補完フレームワークのサポート
+* 追加の補完オプション::  追加の補完オプション
 @end menu
 
 @node アクションの確認
@@ -1739,11 +1775,11 @@ for-each-ref}の@code{--sort}フラグで受け入れられるすべてのキー
 @section Running Git
 
 @menu
-* Viewing Git Output::
-* Git Process Status::
-* Gitを手動で実行::
-* Git実行ファイル::
-* Global Git Arguments::     
+* Viewing Git Output::       Viewing Git Output
+* Git Process Status::       Git Process Status
+* Gitを手動で実行::    Gitを手動で実行
+* Git実行ファイル::    Git実行ファイル
+* Global Git Arguments::     Global Git Arguments
 @end menu
 
 @node Viewing Git Output
@@ -1950,15 +1986,15 @@ Magitが提供する機能は、既存のデータの検査、既存のデータ
 もちろん、他の区別も意味があります。Gitでの磁器コマンドと配管コマンドの区別です。これは、ほとんどの場合、Emacsでのインタラクティブコマンドと非インタラクティブ機能の区別に相当します。前述のすべての節は、主に磁器に関係しています。Magitの配管コマンドレイヤーについては後で説明します。
 
 @menu
-* Status Buffer::
-* Repository List::
-* Logging::
-* Diffing::
-* Ediffing::
-* References Buffer::
-* Bisecting::
-* Visiting Files and Blobs::
-* Blaming::                  
+* Status Buffer::            Status Buffer
+* Repository List::          Repository List
+* Logging::                  Logging
+* Diffing::                  Diffing
+* Ediffing::                 Ediffing
+* References Buffer::        References Buffer
+* Bisecting::                Bisecting
+* Visiting Files and Blobs::  Visiting Files and Blobs
+* Blaming::                  Blaming
 @end menu
 
 @node Status Buffer
@@ -2058,10 +2094,10 @@ Emacs
 @end deffn
 
 @menu
-* Status Sections::
-* Status Header Sections::
-* Status Module Sections::
-* Status Options::           
+* Status Sections::          Status Sections
+* Status Header Sections::   Status Header Sections
+* Status Module Sections::   Status Module Sections
+* Status Options::           Status Options
 @end menu
 
 @node Status Sections
@@ -2518,12 +2554,12 @@ buffer)に表示します。
 Visiting Files})。コマンド@code{magit-cherry}もログを表示します(@ref{Cherries})。
 
 @menu
-* Refreshing Logs::
-* Log Buffer::
-* Log Margin::
-* Select from Log::
-* Reflog::
-* Cherries::                 
+* Refreshing Logs::          Refreshing Logs
+* Log Buffer::               Log Buffer
+* Log Margin::               Log Margin
+* Select from Log::          Select from Log
+* Reflog::                   Reflog
+* Cherries::                 Cherries
 @end menu
 
 @node Refreshing Logs
@@ -2947,10 +2983,10 @@ A@dots{}B)である必要がありますが、単一のコミットにするこ�
 for Buffers Visiting Files})。
 
 @menu
-* Refreshing Diffs::
-* Commands Available in Diffs::
-* Diff Options::
-* Revision Buffer::          
+* Refreshing Diffs::         Refreshing Diffs
+* Commands Available in Diffs::  Commands Available in Diffs
+* Diff Options::             Diff Options
+* Revision Buffer::          Revision Buffer
 @end menu
 
 @node Refreshing Diffs
@@ -3604,7 +3640,7 @@ commitのリストを表示します。
 @end defopt
 
 @menu
-* References Sections::      
+* References Sections::      References Sections
 @end menu
 
 @node References Sections
@@ -3714,8 +3750,9 @@ Magitは、ファイルまたはblob(特定のコミットに保存されてい�
 実際には、そのようなコマンドのいくつかの「グループ」と、各グループ内のいくつかの「バリエーション」を提供します。
 
 @menu
-* General-Purpose Visit Commands::
-* Visiting Files and Blobs from a Diff::  
+* General-Purpose Visit Commands::  General-Purpose Visit Commands
+* Visiting Files and Blobs from a Diff::  Visiting Files and Blobs from a 
+                                            Diff
 @end menu
 
 @node General-Purpose Visit Commands
@@ -3968,18 +4005,18 @@ blameは、以下のオプションを使用して制御されます。
 @chapter Manipulating
 
 @menu
-* Creating Repository::
-* Cloning Repository::
-* Staging and Unstaging::
-* Applying::
-* Committing::
-* Branching::
-* Merging::
-* Resolving Conflicts::
-* Rebasing::
-* Cherry Picking::
-* Resetting::
-* Stashing::                 
+* Creating Repository::      Creating Repository
+* Cloning Repository::       Cloning Repository
+* Staging and Unstaging::    Staging and Unstaging
+* Applying::                 Applying
+* Committing::               Committing
+* Branching::                Branching
+* Merging::                  Merging
+* Resolving Conflicts::      Resolving Conflicts
+* Rebasing::                 Rebasing
+* Cherry Picking::           Cherry Picking
+* Resetting::                Resetting
+* Stashing::                 Stashing
 @end menu
 
 @node Creating Repository
@@ -4196,7 +4233,7 @@ commit)。コミットはユーザーから読み取られ、デフォルトで�
 @end table
 
 @menu
-* Staging from File-Visiting Buffers::  
+* Staging from File-Visiting Buffers::  Staging from File-Visiting Buffers
 @end menu
 
 @node Staging from File-Visiting Buffers
@@ -4280,8 +4317,8 @@ apply}が内部で使用される場合）に3方向マージを試行します�
 commit}を呼び出すため、Gitはユーザーからコミットを取得する必要があります。ファイル@code{.git/COMMIT_EDITMSG}を作成し、そのファイルをエディターで開きます。Magitは、そのエディターがEmacsclientになるように手配します。ユーザーが編集セッションを終了すると、Emacsclientが終了し、Gitはファイルのコンテンツをメッセージとして使用してコミットを作成します。
 
 @menu
-* コミット開始::
-* Editing Commit Messages::  
+* コミット開始::       コミット開始
+* Editing Commit Messages::  Editing Commit Messages
 @end menu
 
 @node コミット開始
@@ -4463,10 +4500,10 @@ commit}によって使用されることに加えて、メッセージはEmacs�
 @end table
 
 @menu
-* Using the Revision Stack::
-* Commit Pseudo Headers::
-* Commit Mode and Hooks::
-* Commit Message Conventions::  
+* Using the Revision Stack::  Using the Revision Stack
+* Commit Pseudo Headers::    Commit Pseudo Headers
+* Commit Mode and Hooks::    Commit Mode and Hooks
+* Commit Message Conventions::  Commit Message Conventions
 @end menu
 
 @node Using the Revision Stack
@@ -4654,10 +4691,10 @@ Git-Commitは、一般的に受け入れられているコミットメッセー�
 @section Branching
 
 @menu
-* The Two Remotes::
-* Branch Commands::
-* Branch Git Variables::
-* Auxiliary Branch Commands::  
+* The Two Remotes::          The Two Remotes
+* Branch Commands::          Branch Commands
+* Branch Git Variables::     Branch Git Variables
+* Auxiliary Branch Commands::  Auxiliary Branch Commands
 @end menu
 
 @node The Two Remotes
@@ -5346,8 +5383,9 @@ Remotes})。
 @end table
 
 @menu
-* Editing Rebase Sequences::
-* Information About In-Progress Rebase::  
+* Editing Rebase Sequences::  Editing Rebase Sequences
+* Information About In-Progress Rebase::  Information About In-Progress 
+                                            Rebase
 @end menu
 
 @node Editing Rebase Sequences
@@ -5709,7 +5747,7 @@ cherry-pickまたはrevertシーケンス中にコミットで中断したもの
 @end table
 
 @menu
-* Reverting::                
+* Reverting::                Reverting
 @end menu
 
 @node Reverting
@@ -5953,20 +5991,20 @@ AUTHOR-WIDTHは整数である必要があります。作成者の名前が表�
 @chapter Transferring
 
 @menu
-* Remotes::
-* Fetching::
-* Pulling::
-* Pushing::
-* Plain Patches::
-* Maildir Patches::          
+* Remotes::                  Remotes
+* Fetching::                 Fetching
+* Pulling::                  Pulling
+* Pushing::                  Pushing
+* Plain Patches::            Plain Patches
+* Maildir Patches::          Maildir Patches
 @end menu
 
 @node Remotes
 @section Remotes
 
 @menu
-* Remote Commands::
-* Remote Git Variables::     
+* Remote Commands::          Remote Commands
+* Remote Git Variables::     Remote Git Variables
 @end menu
 
 @node Remote Commands
@@ -6430,17 +6468,18 @@ buffer)に表示します。
 @chapter Miscellaneous
 
 @menu
-* Tagging::
-* Notes::
-* Submodules::
-* Subtree::
-* Worktree::
-* Sparse checkouts::
-* Bundle::
-* Common Commands::
-* Wip Modes::
-* Commands for Buffers Visiting Files::
-* Minor Mode for Buffers Visiting Blobs::  
+* Tagging::                  Tagging
+* Notes::                    Notes
+* Submodules::               Submodules
+* Subtree::                  Subtree
+* Worktree::                 Worktree
+* Sparse checkouts::         Sparse checkouts
+* Bundle::                   Bundle
+* Common Commands::          Common Commands
+* Wip Modes::                Wip Modes
+* Commands for Buffers Visiting Files::  Commands for Buffers Visiting Files
+* Minor Mode for Buffers Visiting Blobs::  Minor Mode for Buffers Visiting 
+                                             Blobs
 @end menu
 
 @node Tagging
@@ -6595,8 +6634,8 @@ the git-submodule(1) manpage.
 @end iftex
 
 @menu
-* Listing Submodules::
-* submodule用トランジェントコマンド::  
+* Listing Submodules::       Listing Submodules
+* submodule用トランジェントコマンド::  submodule用トランジェントコマンド
 @end menu
 
 @node Listing Submodules
@@ -7021,8 +7060,8 @@ refsの名前は@code{<namespace>index/<branchref>}や@code{<namespace>wtree/<br
 @end defopt
 
 @menu
-* Wip Graph::
-* Legacy Wip Modes::         
+* Wip Graph::                Wip Graph
+* Legacy Wip Modes::         Legacy Wip Modes
 @end menu
 
 @node Wip Graph
@@ -7304,8 +7343,8 @@ GitとEmacsはどちらも高度にカスタマイズ可能です。MagitはGit�
 今後のリリースで、これらの問題や同様の問題に対処する予定です。
 
 @menu
-* Per-Repository Configuration::
-* 基本設定::             
+* Per-Repository Configuration::  Per-Repository Configuration
+* 基本設定::             基本設定
 @end menu
 
 @node Per-Repository Configuration
@@ -7392,9 +7431,9 @@ Variables,,,emacs,})。たとえば、1つの巨大なリポジトリでfile-vis
 次の2つの節は、安全性やパフォーマンス上の理由から、多くのユーザーがカスタマイズする可能性のあるいくつかの変数について説明します。
 
 @menu
-* Safety::
-* Performance::
-* Default Bindings::         
+* Safety::                   Safety
+* Performance::              Performance
+* Default Bindings::         Default Bindings
 @end menu
 
 @node Safety
@@ -7451,8 +7490,8 @@ Magitは、訪問したファイルがディスク上で変更されると、現
 Configuration})。たとえば、非常に多くのタグがあるリポジトリ内の次の現在のタグを判別するのに長い時間がかかります。したがって、前節で説明されているように、@code{magit-insert-tags-headers}を無効にすることをお勧めします。
 
 @menu
-* Microsoft Windows Performance::
-* MacOS Performance::        
+* Microsoft Windows Performance::  Microsoft Windows Performance
+* MacOS Performance::        MacOS Performance
 @end menu
 
 @anchor{Log Performance}
@@ -7590,10 +7629,10 @@ Magitで使用される低レベルの機能のいくつかは、個別の ラ�
 独自のMagit拡張機能によって提供されるコマンドにバインドできる未使用のキーを見つけようとしている場合は、@uref{https://github.com/magit/magit/wiki/Plugin-Dispatch-Key-Registry}をチェックアウトしてください。
 
 @menu
-* Calling Git::
-* Section Plumbing::
-* Refreshing Buffers::
-* 慣習::                   
+* Calling Git::              Calling Git
+* Section Plumbing::         Section Plumbing
+* Refreshing Buffers::       Refreshing Buffers
+* 慣習::                   慣習
 @end menu
 
 @node Calling Git
@@ -7608,8 +7647,8 @@ Magitは、Gitを呼び出すための多くの特殊な関数を提供します
 値のみのグループの関数は常に同期的に実行され、リフレッシュをトリガーすることはありません。副作用グループの関数は、Gitを同期的に実行するか非同期的に実行するか、および実行可能ファイルの終了時にリフレッシュをトリガーするかどうかに応じて、さらにサブグループに分割できます。
 
 @menu
-* Getting a Value from Git::
-* Calling Git for Effect::   
+* Getting a Value from Git::  Getting a Value from Git
+* Calling Git for Effect::   Calling Git for Effect
 @end menu
 
 @node Getting a Value from Git
@@ -7772,9 +7811,9 @@ PROGRAMを開始し、リフレッシュの準備をして、プロセスオブ�
 @section Section Plumbing
 
 @menu
-* Creating Sections::
-* Section Selection::
-* Matching Sections::        
+* Creating Sections::        Creating Sections
+* Section Selection::        Section Selection
+* Matching Sections::        Matching Sections
 @end menu
 
 @node Creating Sections
@@ -7795,7 +7834,11 @@ BODYは、セクションの見出しと本文を実際に挿入する任意の�
 BODYが評価される前に、セクションオブジェクトの@code{start}が@code{point}の値に設定され、BODYが評価された後、その@code{end}が@code{point}の新しい値に設定されます。
 BODYは、@code{point}を前進させる責任があります。
 
-セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}を使用して、部分的に挿入されたセクションのすべてのトレースを中止および削除できます。これは、Gitの出力を洗浄してセクションを作成し、Gitが今回は実際には何も出力しなかった場合に発生する可能性があります。
+If it turns out inside BODY that the section is empty, then
+@code{magit-cancel-section} can be used to abort and remove all traces of
+the partially inserted section.  This can happen when creating a section by
+washing Git's output and Git didn't actually output anything this time
+around.
 @end defmac
 
 @defun magit-insert-heading &rest args
@@ -7889,10 +7932,17 @@ CONDITIONは、以下の形式をとることができます:
 セクションのクラスがCLASSまたはそのサブクラスと同じである場合に一致します。親セクションのクラスに関係なくです。
 @end itemize
 
-各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルである必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもできます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリがある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、セクションもそのタイプに一致します。
+Each CLASS should be a class symbol, identifying a class that derives from
+@code{magit-section}.  For backward compatibility CLASS can also be a "type
+symbol".  A section matches such a symbol if the value of its @code{type}
+slot is @code{eq}.  If a type symbol has an entry in
+@code{magit--section-type-alist}, then a section also matches that type if
+its class is a subclass of the class that corresponds to the type as per
+that alist.
 
-注意:
-もちろん正確にしたい場合を除いて、あなたは@code{magit-describe-section-briefly}によって出力される完全なセクション系統を指定する必要はないことに注意してください。
+Note that it is not necessary to specify the complete section lineage as
+printed by @code{magit-describe-section-briefly}, unless of course you want
+to be that precise.
 @end defun
 
 @defun magit-section-value-if condition &optional section
@@ -7901,7 +7951,7 @@ CONDITIONは、以下の形式をとることができます:
 オプションのSECTIONがnil以外の場合は、代わりにそれが一致するかどうかをテストします。ポイントにセクションがなく、SECTIONがnilの場合は、nilを返します。
 セクションが一致しない場合は、nilを返します。
 
-CONDITIONが取ることができる形式については、@code{magit-section-match}を参照してください。
+See @code{magit-section-match} for the forms CONDITION can take.
 @end defun
 
 @defun magit-section-case &rest clauses
@@ -7979,7 +8029,7 @@ BUFFERに切り替える前に、すべての引数が評価されます。
 こちらもご覧ください(@ref{補完と確認})。
 
 @menu
-* Theming Faces::            
+* Theming Faces::            Theming Faces
 @end menu
 
 @node Theming Faces
@@ -8035,20 +8085,23 @@ whitespace errors)を挿入します。テストに使用します。)
 どうぞこちらご覧下さい @ref{Debugging Tools}
 
 @menu
-* FAQ - How to @dots{}?::
-* FAQ - Issues and Errors::  
+* FAQ - How to @dots{}?::    FAQ - How to @dots{}?
+* FAQ - Issues and Errors::  FAQ - Issues and Errors
 @end menu
 
 @node FAQ - How to @dots{}?
 @appendixsec FAQ - How to @dots{}?
 
 @menu
-* Magitの発音は？::
-* How to show git's output?::
-* How to install the gitman info manual?::
-* How to show diffs for gpg-encrypted files?::
-* How does branching and pushing work?::
-* VCを無効にする必要がありますか？::  
+* Magitの発音は？::     Magitの発音は？
+* How to show git's output?::  How to show git's output?
+* How to install the gitman info manual?::  How to install the gitman info 
+                                              manual?
+* How to show diffs for gpg-encrypted files?::  How to show diffs for 
+                                                  gpg-encrypted files?
+* How does branching and pushing work?::  How does branching and pushing 
+                                            work?
+* VCを無効にする必要がありますか？::  VCを無効にする必要がありますか？
 @end menu
 
 @node Magitの発音は？
@@ -8117,20 +8170,37 @@ echo "*.gpg filter=gpg diff=gpg" > .gitattributes
 @appendixsec FAQ - Issues and Errors
 
 @menu
-* Magit is slow::
-* I changed several thousand files at once and now Magit is unusable::
-* コミットに問題があります::
-* MS WindowsではMagitでpushできません::
-* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.  
-* ファイルを展開してdiffを表示するとファイルが消えます::
-* @code{COMMIT_EDITMSG}バッファのpointが間違っています::
-* モード行の情報が常に最新ではない::
-* 同じ名前を共有するブランチとタグは何かを壊します::
-* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::
-* コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません::
-* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::
-* MS-WindowsからEmacsのTrampモードを使用するとステージできません::
-* 私はポップアップのデフォルトを保存できなくなりました::  
+* Magit is slow::            Magit is slow
+* I changed several thousand files at once and now Magit is unusable::  I 
+                                                                          changed 
+                                                                          several 
+                                                                          thousand 
+                                                                          files 
+                                                                          at 
+                                                                          once 
+                                                                          and 
+                                                                          now 
+                                                                          Magit 
+                                                                          is 
+                                                                          unusable
+* コミットに問題があります::  コミットに問題があります
+* MS WindowsではMagitでpushできません::  MS 
+                                                   WindowsではMagitでpushできません
+* 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません.  私は 
+                                                                                                                                                                                                                                             macOS 
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 
+                                                                                                                                                                                                                                             私は 
+                                                                                                                                                                                                                                             macOS 
+                                                                                                                                                                                                                                             を使用しています。その何かはシェルでは動きますが、Magitでは動きません
+* ファイルを展開してdiffを表示するとファイルが消えます::  ファイルを展開してdiffを表示するとファイルが消えます
+* @code{COMMIT_EDITMSG}バッファのpointが間違っています::  @code{COMMIT_EDITMSG}バッファのpointが間違っています
+* モード行の情報が常に最新ではない::  モード行の情報が常に最新ではない
+* 同じ名前を共有するブランチとタグは何かを壊します::  同じ名前を共有するブランチとタグは何かを壊します
+* 私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::  私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません
+* コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません::  コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません
+* file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります::  file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります
+* MS-WindowsからEmacsのTrampモードを使用するとステージできません::  MS-WindowsからEmacsのTrampモードを使用するとステージできません
+* 私はポップアップのデフォルトを保存できなくなりました::  私はポップアップのデフォルトを保存できなくなりました
 @end menu
 
 @node Magit is slow

--- a/docs/docs-ja/magit.ja.texi
+++ b/docs/docs-ja/magit.ja.texi
@@ -7834,11 +7834,7 @@ BODYは、セクションの見出しと本文を実際に挿入する任意の�
 BODYが評価される前に、セクションオブジェクトの@code{start}が@code{point}の値に設定され、BODYが評価された後、その@code{end}が@code{point}の新しい値に設定されます。
 BODYは、@code{point}を前進させる責任があります。
 
-If it turns out inside BODY that the section is empty, then
-@code{magit-cancel-section} can be used to abort and remove all traces of
-the partially inserted section.  This can happen when creating a section by
-washing Git's output and Git didn't actually output anything this time
-around.
+セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除できます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際には何も出力しなかった場合に発生する可能性があります。
 @end defmac
 
 @defun magit-insert-heading &rest args
@@ -7932,17 +7928,10 @@ CONDITIONは、以下の形式をとることができます:
 セクションのクラスがCLASSまたはそのサブクラスと同じである場合に一致します。親セクションのクラスに関係なくです。
 @end itemize
 
-Each CLASS should be a class symbol, identifying a class that derives from
-@code{magit-section}.  For backward compatibility CLASS can also be a "type
-symbol".  A section matches such a symbol if the value of its @code{type}
-slot is @code{eq}.  If a type symbol has an entry in
-@code{magit--section-type-alist}, then a section also matches that type if
-its class is a subclass of the class that corresponds to the type as per
-that alist.
+各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルである必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもできます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリがある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、セクションもそのタイプに一致します。
 
-Note that it is not necessary to specify the complete section lineage as
-printed by @code{magit-describe-section-briefly}, unless of course you want
-to be that precise.
+注意:
+もちろん、正確にしたい場合を除いて、@code{magit-describe-section-briefly}によって出力される完全なセクション系統を指定する必要はないことに注意してください。
 @end defun
 
 @defun magit-section-value-if condition &optional section
@@ -7951,7 +7940,7 @@ to be that precise.
 オプションのSECTIONがnil以外の場合は、代わりにそれが一致するかどうかをテストします。ポイントにセクションがなく、SECTIONがnilの場合は、nilを返します。
 セクションが一致しない場合は、nilを返します。
 
-See @code{magit-section-match} for the forms CONDITION can take.
+CONDITIONが取ることができる形式については、@code{magit-section-match}を参照してください。
 @end defun
 
 @defun magit-section-case &rest clauses

--- a/docs/docs-ja/po/magit-section.ja.po
+++ b/docs/docs-ja/po/magit-section.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: magit-docs-ja 0.0\n"
-"POT-Creation-Date: 2022-08-23 22:53+0900\n"
+"POT-Creation-Date: 2023-09-08 20:03+0900\n"
 "PO-Revision-Date: 2022-08-25 02:33+0900\n"
 "Last-Translator: kuma35\n"
 "Language-Team: Japanese\n"
@@ -15,25 +15,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. type: top
-#: sed-out/magit-section.texi:4 sed-out/magit-section.texi:33
-#: sed-out/magit-section.texi:45
-#, no-wrap
-msgid "Magit-Section Developer Manual"
-msgstr "Magit-Section Developer Manual"
-
 #. type: Plain text
-#: sed-out/magit-section.texi:8
+#: sed-out/magit.texi:8 sed-out/magit-section.texi:8
 msgid "@documentencoding UTF-8 @documentlanguage en"
 msgstr "@documentencoding UTF-8 @documentlanguage en"
 
 #. type: quotation
-#: sed-out/magit-section.texi:12
+#: sed-out/magit.texi:12 sed-out/magit-section.texi:12
 msgid "Copyright (C) 2015-2022 Jonas Bernoulli <jonas@@bernoul.li>"
 msgstr "Copyright (C) 2015-2022 Jonas Bernoulli <jonas@@bernoul.li>"
 
 #. type: quotation
-#: sed-out/magit-section.texi:17
+#: sed-out/magit.texi:17 sed-out/magit-section.texi:17
 msgid ""
 "You can redistribute this document and/or modify it under the terms of the "
 "GNU General Public License as published by the Free Software Foundation, "
@@ -44,7 +37,7 @@ msgstr ""
 "either version 3 of the License, or (at your option) any later version."
 
 #. type: quotation
-#: sed-out/magit-section.texi:22
+#: sed-out/magit.texi:22 sed-out/magit-section.texi:22
 msgid ""
 "This document is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
@@ -57,10 +50,216 @@ msgstr ""
 "more details."
 
 #. type: dircategory
-#: sed-out/magit-section.texi:26
+#: sed-out/magit.texi:26 sed-out/magit-section.texi:26
 #, no-wrap
 msgid "Emacs"
 msgstr "Magit文書翻訳"
+
+#. type: subtitle
+#: sed-out/magit.texi:34 sed-out/magit-section.texi:34
+#, no-wrap
+msgid "for version 3.3.0-git"
+msgstr "for version 3.3.0-git"
+
+#. type: author
+#: sed-out/magit.texi:35 sed-out/magit-section.texi:35
+#, no-wrap
+msgid "Jonas Bernoulli"
+msgstr "Jonas Bernoulli"
+
+#. type: node
+#: sed-out/magit.texi:44 sed-out/magit-section.texi:44
+#, no-wrap
+msgid "Top"
+msgstr "Top"
+
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:343 sed-out/magit.texi:344
+#: sed-out/magit-section.texi:67 sed-out/magit-section.texi:69
+#: sed-out/magit-section.texi:70
+#, no-wrap
+msgid "Introduction"
+msgstr "Introduction"
+
+#. type: chapter
+#: sed-out/magit.texi:300 sed-out/magit.texi:10243 sed-out/magit.texi:10245
+#: sed-out/magit.texi:10246 sed-out/magit-section.texi:67
+#: sed-out/magit-section.texi:85 sed-out/magit-section.texi:86
+#, no-wrap
+msgid "Creating Sections"
+msgstr "Creating Sections"
+
+#. type: defmac
+#: sed-out/magit.texi:10282 sed-out/magit-section.texi:130
+#, fuzzy
+msgid ""
+"If it turns out inside BODY that the section is empty, then @code{magit-"
+"cancel-section} can be used to abort and remove all traces of the partially "
+"inserted section.  This can happen when creating a section by washing Git's "
+"output and Git didn't actually output anything this time around."
+msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
+"を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除でき"
+"ます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際に"
+"は何も出力しなかった場合に発生する可能性があります。\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
+"セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
+"を使用して、部分的に挿入されたセクションのすべてのトレースを中止および削除で"
+"きます。これは、Gitの出力を洗浄してセクションを作成し、Gitが今回は実際には何"
+"も出力しなかった場合に発生する可能性があります。"
+
+#. type: defun
+#: sed-out/magit.texi:10284 sed-out/magit-section.texi:132
+#, no-wrap
+msgid "magit-insert-heading &rest args"
+msgstr "magit-insert-heading &rest args"
+
+#. type: defun
+#: sed-out/magit.texi:10286 sed-out/magit-section.texi:134
+msgid "Insert the heading for the section currently being inserted."
+msgstr "現在挿入されているセクションの見出しを挿入します。"
+
+#. type: defun
+#: sed-out/magit.texi:10288 sed-out/magit-section.texi:136
+msgid "This function should only be used inside @code{magit-insert-section}."
+msgstr ""
+"この関数は、@code{magit-insert-section}内でのみ使用する必要があります。"
+
+#. type: defun
+#: sed-out/magit.texi:10293 sed-out/magit-section.texi:141
+msgid ""
+"When called without any arguments, then just set the @code{content} slot of "
+"the object representing the section being inserted to a marker at "
+"@code{point}.  The section should only contain a single line when this "
+"function is used like this."
+msgstr ""
+"引数なしで呼び出された場合は、挿入されるセクションを表すオブジェクトの"
+"@code{content}スロットを@code{point}のマーカーに設定するだけです。この関数を"
+"このように使用する場合、セクションには1行のみを含める必要があります。"
+
+#. type: defun
+#: sed-out/magit.texi:10311 sed-out/magit-section.texi:168
+#, no-wrap
+msgid "magit-cancel-section"
+msgstr "magit-cancel-section"
+
+#. type: defun
+#: sed-out/magit.texi:10325 sed-out/magit-section.texi:182
+#, no-wrap
+msgid "magit-current-section"
+msgstr "magit-current-section"
+
+#. type: defun
+#: sed-out/magit.texi:10373 sed-out/magit-section.texi:195
+#, no-wrap
+msgid "magit-section-ident section"
+msgstr "magit-section-ident section"
+
+#. type: defun
+#: sed-out/magit.texi:10378 sed-out/magit-section.texi:212
+#, no-wrap
+msgid "magit-get-section ident &optional root"
+msgstr "magit-get-section ident &optional root"
+
+#. type: defun
+#: sed-out/magit.texi:10390 sed-out/magit-section.texi:264
+msgid "CONDITION can take the following forms:"
+msgstr "CONDITIONは、以下の形式をとることができます:"
+
+#. type: defun
+#: sed-out/magit.texi:10425 sed-out/magit-section.texi:290
+#, fuzzy
+msgid ""
+"Each CLASS should be a class symbol, identifying a class that derives from "
+"@code{magit-section}.  For backward compatibility CLASS can also be a \"type "
+"symbol\".  A section matches such a symbol if the value of its @code{type} "
+"slot is @code{eq}.  If a type symbol has an entry in @code{magit--section-"
+"type-alist}, then a section also matches that type if its class is a "
+"subclass of the class that corresponds to the type as per that alist."
+msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
+"る必要があります。下位互換性のために、CLASSは\"type symbol\"にすることもでき"
+"ます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボ"
+"ルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリが"
+"ある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、"
+"セクションもそのタイプに一致します。\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
+"各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
+"る必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもで"
+"きます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシン"
+"ボルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリ"
+"がある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれ"
+"ば、セクションもそのタイプに一致します。"
+
+#. type: defun
+#: sed-out/magit.texi:10429 sed-out/magit-section.texi:294
+#, fuzzy
+msgid ""
+"Note that it is not necessary to specify the complete section lineage as "
+"printed by @code{magit-describe-section-briefly}, unless of course you want "
+"to be that precise."
+msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"注意: もちろん、正確にしたい場合を除いて、@code{magit-describe-section-"
+"briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
+"してください。\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
+"注意: もちろん正確にしたい場合を除いて、あなたは@code{magit-describe-section-"
+"briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
+"してください。"
+
+#. type: defun
+#: sed-out/magit.texi:10431 sed-out/magit-section.texi:296
+#, no-wrap
+msgid "magit-section-value-if condition &optional section"
+msgstr "magit-section-value-if condition &optional section"
+
+#. type: defun
+#: sed-out/magit.texi:10433 sed-out/magit-section.texi:298
+msgid "If the section at point matches CONDITION, then return its value."
+msgstr "ポイントのセクションがCONDITIONと一致する場合は、その値を返します。"
+
+#. type: defun
+#: sed-out/magit.texi:10438 sed-out/magit-section.texi:303
+msgid ""
+"If optional SECTION is non-nil then test whether that matches instead.  If "
+"there is no section at point and SECTION is nil, then return nil.  If the "
+"section does not match, then return nil."
+msgstr ""
+"オプションのSECTIONがnil以外の場合は、代わりにそれが一致するかどうかをテスト"
+"します。ポイントにセクションがなく、SECTIONがnilの場合は、nilを返します。 セ"
+"クションが一致しない場合は、nilを返します。"
+
+#. type: defun
+#: sed-out/magit.texi:10440 sed-out/magit-section.texi:305
+#, fuzzy
+msgid "See @code{magit-section-match} for the forms CONDITION can take."
+msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"CONDITIONが取ることができる形式については→@code{magit-section-match}\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
+"CONDITIONが取ることができる形式については、@code{magit-section-match}を参照し"
+"てください。"
+
+#. type: defmac
+#: sed-out/magit.texi:10442 sed-out/magit-section.texi:307
+#, no-wrap
+msgid "magit-section-case &rest clauses"
+msgstr "magit-section-case &rest clauses"
+
+#. type: defmac
+#: sed-out/magit.texi:10444 sed-out/magit-section.texi:309
+msgid "Choose among clauses on the type of the section at point."
+msgstr "ポイントのセクションのタイプに関する条項(clauses)から選択します。"
+
+#. type: top
+#: sed-out/magit-section.texi:4 sed-out/magit-section.texi:33
+#: sed-out/magit-section.texi:45
+#, no-wrap
+msgid "Magit-Section Developer Manual"
+msgstr "Magit-Section Developer Manual"
 
 #. type: menuentry
 #: sed-out/magit-section.texi:29
@@ -71,24 +270,6 @@ msgstr "Magit-Section(ja): (magit-section.ja)"
 #: sed-out/magit-section.texi:29
 msgid "Use Magit sections in your own packages."
 msgstr "あなた独自のパッケージでMagit sectionを使用します。"
-
-#. type: subtitle
-#: sed-out/magit-section.texi:34
-#, no-wrap
-msgid "for version 3.3.0-git"
-msgstr "for version 3.3.0-git"
-
-#. type: author
-#: sed-out/magit-section.texi:35
-#, no-wrap
-msgid "Jonas Bernoulli"
-msgstr "Jonas Bernoulli"
-
-#. type: node
-#: sed-out/magit-section.texi:44
-#, no-wrap
-msgid "Top"
-msgstr "Top"
 
 #. type: Plain text
 #: sed-out/magit-section.texi:51 sed-out/magit-section.texi:76
@@ -117,22 +298,15 @@ msgstr ""
 #. type: ifnottex
 #: sed-out/magit-section.texi:58
 msgid "This manual is for Magit-Section version 3.3.0-git."
-msgstr "このマニュアルは、Magit-Sectionバージョン 3.3.0-git を対象としています。"
+msgstr ""
+"このマニュアルは、Magit-Sectionバージョン 3.3.0-git を対象としています。"
 
-#. type: menuentry
-#: sed-out/magit-section.texi:67
-msgid "Introduction::"
-msgstr "Introduction::"
-
-#. type: menuentry
-#: sed-out/magit-section.texi:67
-msgid "Creating Sections::"
-msgstr "Creating Sections::"
-
-#. type: menuentry
-#: sed-out/magit-section.texi:67
-msgid "Core Functions::"
-msgstr "Core Functions::"
+#. type: chapter
+#: sed-out/magit-section.texi:67 sed-out/magit-section.texi:179
+#: sed-out/magit-section.texi:180
+#, no-wrap
+msgid "Core Functions"
+msgstr "Core Functions"
 
 #. type: chapter
 #: sed-out/magit-section.texi:67 sed-out/magit-section.texi:253
@@ -140,12 +314,6 @@ msgstr "Core Functions::"
 #, no-wrap
 msgid "Matching Functions"
 msgstr "Matching Functions"
-
-#. type: chapter
-#: sed-out/magit-section.texi:69 sed-out/magit-section.texi:70
-#, no-wrap
-msgid "Introduction"
-msgstr "Introduction"
 
 #. type: Plain text
 #: sed-out/magit-section.texi:84
@@ -157,12 +325,6 @@ msgstr ""
 "ドキュメントに対処されていないものが残っている場合は、Magitがこのライブラリを"
 "広範囲に使用していることを鑑み、助けを求める前にまずはMagit関係の方で適切な例"
 "を検索してください。宜しくお願いします。"
-
-#. type: chapter
-#: sed-out/magit-section.texi:85 sed-out/magit-section.texi:86
-#, no-wrap
-msgid "Creating Sections"
-msgstr "Creating Sections"
 
 #. type: defmac
 #: sed-out/magit-section.texi:88
@@ -251,48 +413,6 @@ msgstr ""
 "され、BODYが評価された後、その@code{end}が@code{point}の新しい値に設定されま"
 "す。BODYは、@code{point}を前進させる責任があります。"
 
-#. type: defmac
-#: sed-out/magit-section.texi:130
-msgid ""
-"If it turns out inside BODY that the section is empty, then @code{magit-"
-"cancel-section} can be used to abort and remove all traces of the partially "
-"inserted section.  This can happen when creating a section by washing Git's "
-"output and Git didn't actually output anything this time around."
-msgstr ""
-"セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
-"を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除でき"
-"ます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際に"
-"は何も出力しなかった場合に発生する可能性があります。"
-
-#. type: defun
-#: sed-out/magit-section.texi:132
-#, no-wrap
-msgid "magit-insert-heading &rest args"
-msgstr "magit-insert-heading &rest args"
-
-#. type: defun
-#: sed-out/magit-section.texi:134
-msgid "Insert the heading for the section currently being inserted."
-msgstr "現在挿入されているセクションの見出しを挿入します。"
-
-#. type: defun
-#: sed-out/magit-section.texi:136
-msgid "This function should only be used inside @code{magit-insert-section}."
-msgstr ""
-"この関数は、@code{magit-insert-section}内でのみ使用する必要があります。"
-
-#. type: defun
-#: sed-out/magit-section.texi:141
-msgid ""
-"When called without any arguments, then just set the @code{content} slot of "
-"the object representing the section being inserted to a marker at "
-"@code{point}.  The section should only contain a single line when this "
-"function is used like this."
-msgstr ""
-"引数なしで呼び出された場合は、挿入されるセクションを表すオブジェクトの"
-"@code{content}スロットを@code{point}のマーカーに設定するだけです。この関数を"
-"このように使用する場合、セクションには1行のみを含める必要があります。"
-
 #. type: defun
 #: sed-out/magit-section.texi:149
 msgid ""
@@ -349,12 +469,6 @@ msgstr ""
 "ん。"
 
 #. type: defun
-#: sed-out/magit-section.texi:168
-#, no-wrap
-msgid "magit-cancel-section"
-msgstr "magit-cancel-section"
-
-#. type: defun
 #: sed-out/magit-section.texi:171
 msgid ""
 "Cancel inserting the section that is currently being inserted.  Remove all "
@@ -379,18 +493,6 @@ msgstr ""
 "出します。FUNCTIONは、ポイントを前方に移動するか、@code{nil}を返す必要があり"
 "ます。"
 
-#. type: chapter
-#: sed-out/magit-section.texi:179 sed-out/magit-section.texi:180
-#, no-wrap
-msgid "Core Functions"
-msgstr "Core Functions"
-
-#. type: defun
-#: sed-out/magit-section.texi:182
-#, no-wrap
-msgid "magit-current-section"
-msgstr "magit-current-section"
-
 #. type: defun
 #: sed-out/magit-section.texi:187
 msgid ""
@@ -398,7 +500,11 @@ msgid ""
 "using the context menu, return the section that the user clicked on, "
 "provided the current buffer is the buffer in which the click occurred.  "
 "Otherwise return the section at point."
-msgstr "ポイントまたはコンテキストメニューが呼び出された場所のセクションを返します。 コンテキストメニューを使用する場合、クリックが発生したバッファーが現在のバッファーである場合、ユーザーがクリックしたセクションを返します。 それ以外の場合は、ポイントのセクションを返します。"
+msgstr ""
+"ポイントまたはコンテキストメニューが呼び出された場所のセクションを返します。 "
+"コンテキストメニューを使用する場合、クリックが発生したバッファーが現在のバッ"
+"ファーである場合、ユーザーがクリックしたセクションを返します。 それ以外の場合"
+"は、ポイントのセクションを返します。"
 
 #. type: item
 #: sed-out/magit-section.texi:190
@@ -411,13 +517,9 @@ msgstr "Function magit-section-at &optional position"
 msgid ""
 "Return the section at POSITION, defaulting to point.  Default to point even "
 "when the context menu is used."
-msgstr "POSITION のセクションを返します。デフォルトはポイントです。 コンテキストメニューが使用されている場合でも、デフォルトでポイントします。"
-
-#. type: defun
-#: sed-out/magit-section.texi:195
-#, no-wrap
-msgid "magit-section-ident section"
-msgstr "magit-section-ident section"
+msgstr ""
+"POSITION のセクションを返します。デフォルトはポイントです。 コンテキストメ"
+"ニューが使用されている場合でも、デフォルトでポイントします。"
 
 #. type: defun
 #: sed-out/magit-section.texi:198
@@ -456,12 +558,6 @@ msgstr ""
 "の場合は、引数自体を返すだけのcatch-allメソッドが使用されます。"
 
 #. type: defun
-#: sed-out/magit-section.texi:212
-#, no-wrap
-msgid "magit-get-section ident &optional root"
-msgstr "magit-get-section ident &optional root"
-
-#. type: defun
 #: sed-out/magit-section.texi:217
 msgid ""
 "Return the section identified by IDENT@.  IDENT has to be a list as returned "
@@ -497,7 +593,9 @@ msgstr "magit-section-content-p section"
 #. type: defun
 #: sed-out/magit-section.texi:226
 msgid "Return non-nil if SECTION has content or an unused washer function."
-msgstr "SECTION にコンテンツまたは未使用のウォッシャー関数がある場合、非 nil を返します。"
+msgstr ""
+"SECTION にコンテンツまたは未使用のウォッシャー関数がある場合、非 nil を返しま"
+"す。"
 
 #. type: Plain text
 #: sed-out/magit-section.texi:232
@@ -506,7 +604,11 @@ msgid ""
 "the same name except for the @code{magit-} prefix.  Like @code{magit-current-"
 "section} they do not act on point, the cursors position, but on the position "
 "where the user clicked to invoke the context menu."
-msgstr "次の 2 つの関数は、 @code{magit-} プレフィックスを除いて同じ名前を持つ Emacs 関数の置き換えです。 @code{magit-current-section} のように、カーソルの位置ではなく、ユーザーがコンテキストメニューを呼び出すためにクリックした位置で動作します。"
+msgstr ""
+"次の 2 つの関数は、 @code{magit-} プレフィックスを除いて同じ名前を持つ Emacs "
+"関数の置き換えです。 @code{magit-current-section} のように、カーソルの位置で"
+"はなく、ユーザーがコンテキストメニューを呼び出すためにクリックした位置で動作"
+"します。"
 
 #. type: Plain text
 #: sed-out/magit-section.texi:237
@@ -514,7 +616,10 @@ msgid ""
 "If your package provides a context menu and some of its commands act on the "
 "\"thing at point\", even if just as a default, then use the prefixed "
 "functions to teach them to instead use the click location when appropriate."
-msgstr "あなたのパッケージがコンテキストメニューを提供し、そのコマンドの一部がデフォルトであっても「ポイントにあるもの」に作用する場合は、接頭辞付きの関数を使用して、必要に応じて代わりにクリック位置を使用するように教えてください。"
+msgstr ""
+"あなたのパッケージがコンテキストメニューを提供し、そのコマンドの一部がデフォ"
+"ルトであっても「ポイントにあるもの」に作用する場合は、接頭辞付きの関数を使用"
+"して、必要に応じて代わりにクリック位置を使用するように教えてください。"
 
 #. type: item
 #: sed-out/magit-section.texi:239
@@ -529,7 +634,11 @@ msgid ""
 "the context menu, return the position the user clicked on, provided the "
 "current buffer is the buffer in which the click occurred.  Otherwise return "
 "the same value as @code{point}."
-msgstr "コンテキストメニューが呼び出されたリターンポイントまたは位置。 コンテキストメニューを使用する場合、現在のバッファーがクリックが発生したバッファーである場合、ユーザーがクリックした位置を返します。 それ以外の場合は、@code{point} と同じ値を返します。"
+msgstr ""
+"コンテキストメニューが呼び出されたリターンポイントまたは位置。 コンテキストメ"
+"ニューを使用する場合、現在のバッファーがクリックが発生したバッファーである場"
+"合、ユーザーがクリックした位置を返します。 それ以外の場合は、@code{point} と"
+"同じ値を返します。"
 
 #. type: item
 #: sed-out/magit-section.texi:245
@@ -545,7 +654,12 @@ msgid ""
 "buffer is the buffer in which the click occurred.  Otherwise return the same "
 "value as @code{thing-at-point}.  For the meaning of THING and NO-PROPERTIES "
 "see that function."
-msgstr "ポイントまたはコンテキストメニューが呼び出された場所でTHINGを返します。 コンテキストメニューを使用する場合、現在のバッファがクリックが発生したバッファである場合、ユーザーがクリックしたものを返します。 それ以外の場合は、@code{thing-at-point} と同じ値を返します。 THING と NO-PROPERTIES の意味については、当該の関数を参照してください。"
+msgstr ""
+"ポイントまたはコンテキストメニューが呼び出された場所でTHINGを返します。 コン"
+"テキストメニューを使用する場合、現在のバッファがクリックが発生したバッファで"
+"ある場合、ユーザーがクリックしたものを返します。 それ以外の場合は、"
+"@code{thing-at-point} と同じ値を返します。 THING と NO-PROPERTIES の意味につ"
+"いては、当該の関数を参照してください。"
 
 #. type: defun
 #: sed-out/magit-section.texi:256
@@ -566,11 +680,6 @@ msgid ""
 msgstr ""
 "SECTIONは、デフォルトでポイントのセクションになります。SECTIONが指定されてお"
 "らず、ポイントにもセクションがない場合は、nilを返します。"
-
-#. type: defun
-#: sed-out/magit-section.texi:264
-msgid "CONDITION can take the following forms:"
-msgstr "CONDITIONは、以下の形式をとることができます:"
 
 #. type: itemize
 #: sed-out/magit-section.texi:268
@@ -606,72 +715,6 @@ msgid ""
 msgstr ""
 "@code{CLASS} 親セクションのクラスには関係なく、セクションのクラスがCLASSまた"
 "はそのサブクラスと同じである場合に一致します。"
-
-#. type: defun
-#: sed-out/magit-section.texi:290
-msgid ""
-"Each CLASS should be a class symbol, identifying a class that derives from "
-"@code{magit-section}.  For backward compatibility CLASS can also be a \"type "
-"symbol\".  A section matches such a symbol if the value of its @code{type} "
-"slot is @code{eq}.  If a type symbol has an entry in @code{magit--section-"
-"type-alist}, then a section also matches that type if its class is a "
-"subclass of the class that corresponds to the type as per that alist."
-msgstr ""
-"各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
-"る必要があります。下位互換性のために、CLASSは\"type symbol\"にすることもでき"
-"ます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボ"
-"ルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリが"
-"ある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、"
-"セクションもそのタイプに一致します。"
-
-#. type: defun
-#: sed-out/magit-section.texi:294
-msgid ""
-"Note that it is not necessary to specify the complete section lineage as "
-"printed by @code{magit-describe-section-briefly}, unless of course you want "
-"to be that precise."
-msgstr ""
-"注意: もちろん、正確にしたい場合を除いて、@code{magit-describe-section-"
-"briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
-"してください。"
-
-#. type: defun
-#: sed-out/magit-section.texi:296
-#, no-wrap
-msgid "magit-section-value-if condition &optional section"
-msgstr "magit-section-value-if condition &optional section"
-
-#. type: defun
-#: sed-out/magit-section.texi:298
-msgid "If the section at point matches CONDITION, then return its value."
-msgstr "ポイントのセクションがCONDITIONと一致する場合は、その値を返します。"
-
-#. type: defun
-#: sed-out/magit-section.texi:303
-msgid ""
-"If optional SECTION is non-nil then test whether that matches instead.  If "
-"there is no section at point and SECTION is nil, then return nil.  If the "
-"section does not match, then return nil."
-msgstr ""
-"オプションのSECTIONがnil以外の場合は、代わりにそれが一致するかどうかをテスト"
-"します。ポイントにセクションがなく、SECTIONがnilの場合は、nilを返します。 セ"
-"クションが一致しない場合は、nilを返します。"
-
-#. type: defun
-#: sed-out/magit-section.texi:305
-msgid "See @code{magit-section-match} for the forms CONDITION can take."
-msgstr "CONDITIONが取ることができる形式については→@code{magit-section-match}"
-
-#. type: defmac
-#: sed-out/magit-section.texi:307
-#, no-wrap
-msgid "magit-section-case &rest clauses"
-msgstr "magit-section-case &rest clauses"
-
-#. type: defmac
-#: sed-out/magit-section.texi:309
-msgid "Choose among clauses on the type of the section at point."
-msgstr "ポイントのセクションのタイプに関する条項(clauses)から選択します。"
 
 #. type: defmac
 #: sed-out/magit-section.texi:316

--- a/docs/docs-ja/po/magit-section.ja.po
+++ b/docs/docs-ja/po/magit-section.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: magit-docs-ja 0.0\n"
-"POT-Creation-Date: 2023-09-08 20:03+0900\n"
+"POT-Creation-Date: 2023-09-08 20:19+0900\n"
 "PO-Revision-Date: 2022-08-25 02:33+0900\n"
 "Last-Translator: kuma35\n"
 "Language-Team: Japanese\n"
@@ -91,23 +91,16 @@ msgstr "Creating Sections"
 
 #. type: defmac
 #: sed-out/magit.texi:10282 sed-out/magit-section.texi:130
-#, fuzzy
 msgid ""
 "If it turns out inside BODY that the section is empty, then @code{magit-"
 "cancel-section} can be used to abort and remove all traces of the partially "
 "inserted section.  This can happen when creating a section by washing Git's "
 "output and Git didn't actually output anything this time around."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
 "セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
 "を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除でき"
 "ます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際に"
-"は何も出力しなかった場合に発生する可能性があります。\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
-"セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
-"を使用して、部分的に挿入されたセクションのすべてのトレースを中止および削除で"
-"きます。これは、Gitの出力を洗浄してセクションを作成し、Gitが今回は実際には何"
-"も出力しなかった場合に発生する可能性があります。"
+"は何も出力しなかった場合に発生する可能性があります。"
 
 #. type: defun
 #: sed-out/magit.texi:10284 sed-out/magit-section.texi:132
@@ -169,7 +162,6 @@ msgstr "CONDITIONは、以下の形式をとることができます:"
 
 #. type: defun
 #: sed-out/magit.texi:10425 sed-out/magit-section.texi:290
-#, fuzzy
 msgid ""
 "Each CLASS should be a class symbol, identifying a class that derives from "
 "@code{magit-section}.  For backward compatibility CLASS can also be a \"type "
@@ -178,14 +170,6 @@ msgid ""
 "type-alist}, then a section also matches that type if its class is a "
 "subclass of the class that corresponds to the type as per that alist."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
-"各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
-"る必要があります。下位互換性のために、CLASSは\"type symbol\"にすることもでき"
-"ます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボ"
-"ルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリが"
-"ある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、"
-"セクションもそのタイプに一致します。\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
 "る必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもで"
 "きます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシン"
@@ -195,18 +179,12 @@ msgstr ""
 
 #. type: defun
 #: sed-out/magit.texi:10429 sed-out/magit-section.texi:294
-#, fuzzy
 msgid ""
 "Note that it is not necessary to specify the complete section lineage as "
 "printed by @code{magit-describe-section-briefly}, unless of course you want "
 "to be that precise."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
 "注意: もちろん、正確にしたい場合を除いて、@code{magit-describe-section-"
-"briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
-"してください。\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
-"注意: もちろん正確にしたい場合を除いて、あなたは@code{magit-describe-section-"
 "briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
 "してください。"
 
@@ -234,12 +212,8 @@ msgstr ""
 
 #. type: defun
 #: sed-out/magit.texi:10440 sed-out/magit-section.texi:305
-#, fuzzy
 msgid "See @code{magit-section-match} for the forms CONDITION can take."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
-"CONDITIONが取ることができる形式については→@code{magit-section-match}\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "CONDITIONが取ることができる形式については、@code{magit-section-match}を参照し"
 "てください。"
 

--- a/docs/docs-ja/po/magit.ja.po
+++ b/docs/docs-ja/po/magit.ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: magit-docs-ja 0.1\n"
-"POT-Creation-Date: 2023-09-08 20:03+0900\n"
-"PO-Revision-Date: 2022-08-25 02:14+0900\n"
+"POT-Creation-Date: 2023-09-08 20:19+0900\n"
+"PO-Revision-Date: 2023-09-08 20:25+0900\n"
 "Last-Translator: kuma35\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
@@ -26090,23 +26090,16 @@ msgstr ""
 
 #. type: defmac
 #: sed-out/magit.texi:10282 sed-out/magit-section.texi:130
-#, fuzzy
 msgid ""
 "If it turns out inside BODY that the section is empty, then @code{magit-"
 "cancel-section} can be used to abort and remove all traces of the partially "
 "inserted section.  This can happen when creating a section by washing Git's "
 "output and Git didn't actually output anything this time around."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
 "セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
 "を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除でき"
 "ます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際に"
-"は何も出力しなかった場合に発生する可能性があります。\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
-"セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
-"を使用して、部分的に挿入されたセクションのすべてのトレースを中止および削除で"
-"きます。これは、Gitの出力を洗浄してセクションを作成し、Gitが今回は実際には何"
-"も出力しなかった場合に発生する可能性があります。"
+"は何も出力しなかった場合に発生する可能性があります。"
 
 #. type: defun
 #: sed-out/magit.texi:10284 sed-out/magit-section.texi:132
@@ -26424,7 +26417,6 @@ msgstr ""
 
 #. type: defun
 #: sed-out/magit.texi:10425 sed-out/magit-section.texi:290
-#, fuzzy
 msgid ""
 "Each CLASS should be a class symbol, identifying a class that derives from "
 "@code{magit-section}.  For backward compatibility CLASS can also be a \"type "
@@ -26433,14 +26425,6 @@ msgid ""
 "type-alist}, then a section also matches that type if its class is a "
 "subclass of the class that corresponds to the type as per that alist."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
-"各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
-"る必要があります。下位互換性のために、CLASSは\"type symbol\"にすることもでき"
-"ます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボ"
-"ルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリが"
-"ある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、"
-"セクションもそのタイプに一致します。\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
 "る必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもで"
 "きます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシン"
@@ -26450,18 +26434,12 @@ msgstr ""
 
 #. type: defun
 #: sed-out/magit.texi:10429 sed-out/magit-section.texi:294
-#, fuzzy
 msgid ""
 "Note that it is not necessary to specify the complete section lineage as "
 "printed by @code{magit-describe-section-briefly}, unless of course you want "
 "to be that precise."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
 "注意: もちろん、正確にしたい場合を除いて、@code{magit-describe-section-"
-"briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
-"してください。\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
-"注意: もちろん正確にしたい場合を除いて、あなたは@code{magit-describe-section-"
 "briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
 "してください。"
 
@@ -26489,12 +26467,8 @@ msgstr ""
 
 #. type: defun
 #: sed-out/magit.texi:10440 sed-out/magit-section.texi:305
-#, fuzzy
 msgid "See @code{magit-section-match} for the forms CONDITION can take."
 msgstr ""
-"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
-"CONDITIONが取ることができる形式については→@code{magit-section-match}\n"
-"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "CONDITIONが取ることができる形式については、@code{magit-section-match}を参照し"
 "てください。"
 

--- a/docs/docs-ja/po/magit.ja.po
+++ b/docs/docs-ja/po/magit.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: magit-docs-ja 0.1\n"
-"POT-Creation-Date: 2022-08-23 22:28+0900\n"
+"POT-Creation-Date: 2023-09-08 20:03+0900\n"
 "PO-Revision-Date: 2022-08-25 02:14+0900\n"
 "Last-Translator: kuma35\n"
 "Language-Team: Japanese\n"
@@ -22,17 +22,17 @@ msgid "Magit User Manual"
 msgstr "Magit User Manual"
 
 #. type: Plain text
-#: sed-out/magit.texi:8
+#: sed-out/magit.texi:8 sed-out/magit-section.texi:8
 msgid "@documentencoding UTF-8 @documentlanguage en"
 msgstr "@documentencoding UTF-8 @documentlanguage en"
 
 #. type: quotation
-#: sed-out/magit.texi:12
+#: sed-out/magit.texi:12 sed-out/magit-section.texi:12
 msgid "Copyright (C) 2015-2022 Jonas Bernoulli <jonas@@bernoul.li>"
 msgstr "Copyright (C) 2015-2022 Jonas Bernoulli <jonas@@bernoul.li>"
 
 #. type: quotation
-#: sed-out/magit.texi:17
+#: sed-out/magit.texi:17 sed-out/magit-section.texi:17
 msgid ""
 "You can redistribute this document and/or modify it under the terms of the "
 "GNU General Public License as published by the Free Software Foundation, "
@@ -43,7 +43,7 @@ msgstr ""
 "either version 3 of the License, or (at your option) any later version."
 
 #. type: quotation
-#: sed-out/magit.texi:22
+#: sed-out/magit.texi:22 sed-out/magit-section.texi:22
 msgid ""
 "This document is distributed in the hope that it will be useful, but WITHOUT "
 "ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
@@ -56,7 +56,7 @@ msgstr ""
 "more details."
 
 #. type: dircategory
-#: sed-out/magit.texi:26
+#: sed-out/magit.texi:26 sed-out/magit-section.texi:26
 #, no-wrap
 msgid "Emacs"
 msgstr "Magit文書翻訳"
@@ -72,19 +72,19 @@ msgid "Using Git from Emacs with Magit."
 msgstr "MagitでEmacsのGitを使用する。"
 
 #. type: subtitle
-#: sed-out/magit.texi:34
+#: sed-out/magit.texi:34 sed-out/magit-section.texi:34
 #, no-wrap
 msgid "for version 3.3.0-git"
 msgstr "for version 3.3.0-git"
 
 #. type: author
-#: sed-out/magit.texi:35
+#: sed-out/magit.texi:35 sed-out/magit-section.texi:35
 #, no-wrap
 msgid "Jonas Bernoulli"
 msgstr "Jonas Bernoulli"
 
 #. type: node
-#: sed-out/magit.texi:44
+#: sed-out/magit.texi:44 sed-out/magit-section.texi:44
 #, no-wrap
 msgid "Top"
 msgstr "Top"
@@ -120,75 +120,100 @@ msgstr ""
 msgid "This manual is for Magit version 3.3.0-git."
 msgstr "This manual is for Magit version 3.3.0-git."
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Introduction::"
-msgstr "Introduction::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:343 sed-out/magit.texi:344
+#: sed-out/magit-section.texi:67 sed-out/magit-section.texi:69
+#: sed-out/magit-section.texi:70
+#, no-wrap
+msgid "Introduction"
+msgstr "Introduction"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Installation::"
-msgstr "Installation::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:82 sed-out/magit.texi:422
+#: sed-out/magit.texi:423
+#, no-wrap
+msgid "Installation"
+msgstr "Installation"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Getting Started::"
-msgstr "Getting Started::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:598 sed-out/magit.texi:599
+#, no-wrap
+msgid "Getting Started"
+msgstr "Getting Started"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Interface Concepts::"
-msgstr "Interface Concepts::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:88 sed-out/magit.texi:698
+#: sed-out/magit.texi:699
+#, no-wrap
+msgid "Interface Concepts"
+msgstr "Interface Concepts"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Inspecting::"
-msgstr "Inspecting::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:136 sed-out/magit.texi:2593
+#: sed-out/magit.texi:2594
+#, no-wrap
+msgid "Inspecting"
+msgstr "Inspecting"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Manipulating::"
-msgstr "Manipulating::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:185 sed-out/magit.texi:5211
+#: sed-out/magit.texi:5212
+#, no-wrap
+msgid "Manipulating"
+msgstr "Manipulating"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Transferring::"
-msgstr "Transferring::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:230 sed-out/magit.texi:7891
+#: sed-out/magit.texi:7892
+#, no-wrap
+msgid "Transferring"
+msgstr "Transferring"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Miscellaneous::"
-msgstr "Miscellaneous::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:245 sed-out/magit.texi:8469
+#: sed-out/magit.texi:8470
+#, no-wrap
+msgid "Miscellaneous"
+msgstr "Miscellaneous"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Customizing::"
-msgstr "Customizing::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:271 sed-out/magit.texi:9520
+#: sed-out/magit.texi:9521
+#, no-wrap
+msgid "Customizing"
+msgstr "Customizing"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Plumbing::"
-msgstr "配管コマンド(Plumbing)::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:283 sed-out/magit.texi:9952
+#: sed-out/magit.texi:9953
+#, no-wrap
+msgid "Plumbing"
+msgstr "配管コマンド(Plumbing)"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "FAQ::"
-msgstr "FAQ::"
+#. type: appendix
+#: sed-out/magit.texi:77 sed-out/magit.texi:308 sed-out/magit.texi:10719
+#: sed-out/magit.texi:10720
+#, no-wrap
+msgid "FAQ"
+msgstr "FAQ"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Debugging Tools::"
-msgstr "Debugging Tools::"
+#. type: chapter
+#: sed-out/magit.texi:77 sed-out/magit.texi:11077 sed-out/magit.texi:11078
+#, no-wrap
+msgid "Debugging Tools"
+msgstr "Debugging Tools"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Keystroke Index::"
-msgstr "Keystroke Index::"
+#. type: appendix
+#: sed-out/magit.texi:77 sed-out/magit.texi:11157 sed-out/magit.texi:11158
+#, no-wrap
+msgid "Keystroke Index"
+msgstr "Keystroke Index"
 
-#. type: menuentry
-#: sed-out/magit.texi:77
-msgid "Function and Command Index::"
-msgstr "Function and Command Index::"
+#. type: appendix
+#: sed-out/magit.texi:77 sed-out/magit.texi:11162 sed-out/magit.texi:11163
+#, no-wrap
+msgid "Function and Command Index"
+msgstr "Function and Command Index"
 
 #. type: appendix
 #: sed-out/magit.texi:77 sed-out/magit.texi:11167 sed-out/magit.texi:11168
@@ -201,21 +226,19 @@ msgstr "Variable Index"
 msgid "--- The Detailed Node Listing ---"
 msgstr "--- The Detailed Node Listing ---"
 
-#. type: chapter
-#: sed-out/magit.texi:82 sed-out/magit.texi:422 sed-out/magit.texi:423
+#. type: section
+#: sed-out/magit.texi:86 sed-out/magit.texi:432 sed-out/magit.texi:434
+#: sed-out/magit.texi:435
 #, no-wrap
-msgid "Installation"
-msgstr "Installation"
+msgid "Installing from Melpa"
+msgstr "Installing from Melpa"
 
-#. type: menuentry
-#: sed-out/magit.texi:86 sed-out/magit.texi:432
-msgid "Installing from Melpa::"
-msgstr "Installing from Melpa::"
-
-#. type: menuentry
-#: sed-out/magit.texi:86 sed-out/magit.texi:432
-msgid "Installing from the Git Repository::"
-msgstr "Installing from the Git Repository::"
+#. type: section
+#: sed-out/magit.texi:86 sed-out/magit.texi:432 sed-out/magit.texi:481
+#: sed-out/magit.texi:482
+#, no-wrap
+msgid "Installing from the Git Repository"
+msgstr "Installing from the Git Repository"
 
 #. type: section
 #: sed-out/magit.texi:86 sed-out/magit.texi:432 sed-out/magit.texi:563
@@ -224,31 +247,33 @@ msgstr "Installing from the Git Repository::"
 msgid "Post-Installation Tasks"
 msgstr "Post-Installation Tasks"
 
-#. type: chapter
-#: sed-out/magit.texi:88 sed-out/magit.texi:698 sed-out/magit.texi:699
+#. type: section
+#: sed-out/magit.texi:96 sed-out/magit.texi:98 sed-out/magit.texi:709
+#: sed-out/magit.texi:711 sed-out/magit.texi:712
 #, no-wrap
-msgid "Interface Concepts"
-msgstr "Interface Concepts"
+msgid "Modes and Buffers"
+msgstr "Modes and Buffers"
 
-#. type: menuentry
-#: sed-out/magit.texi:96 sed-out/magit.texi:709
-msgid "Modes and Buffers::"
-msgstr "Modes and Buffers::"
+#. type: section
+#: sed-out/magit.texi:96 sed-out/magit.texi:108 sed-out/magit.texi:709
+#: sed-out/magit.texi:1240 sed-out/magit.texi:1241
+#, no-wrap
+msgid "Sections"
+msgstr "Sections"
 
-#. type: menuentry
-#: sed-out/magit.texi:96 sed-out/magit.texi:709
-msgid "Sections::"
-msgstr "Sections::"
+#. type: section
+#: sed-out/magit.texi:96 sed-out/magit.texi:709 sed-out/magit.texi:1662
+#: sed-out/magit.texi:1663
+#, no-wrap
+msgid "Transient Commands"
+msgstr "トランジェントコマンド"
 
-#. type: menuentry
-#: sed-out/magit.texi:96 sed-out/magit.texi:709
-msgid "Transient Commands::"
-msgstr "トランジェントコマンド::"
-
-#. type: menuentry
-#: sed-out/magit.texi:96 sed-out/magit.texi:709
-msgid "Transient Arguments and Buffer Variables::"
-msgstr "Transient Arguments and Buffer Variables::"
+#. type: section
+#: sed-out/magit.texi:96 sed-out/magit.texi:709 sed-out/magit.texi:1695
+#: sed-out/magit.texi:1696
+#, no-wrap
+msgid "Transient Arguments and Buffer Variables"
+msgstr "Transient Arguments and Buffer Variables"
 
 #. type: menuentry
 #: sed-out/magit.texi:96 sed-out/magit.texi:709
@@ -259,10 +284,12 @@ msgstr ""
 "Completion(補完)とConfirmation(確認)とSelection(選択範囲): Completion "
 "Confirmation(確認補完)とSelection(選択範囲)"
 
-#. type: menuentry
-#: sed-out/magit.texi:96 sed-out/magit.texi:709
-msgid "Mouse Support::"
-msgstr "Mouse Support::"
+#. type: section
+#: sed-out/magit.texi:96 sed-out/magit.texi:709 sed-out/magit.texi:2298
+#: sed-out/magit.texi:2299
+#, no-wrap
+msgid "Mouse Support"
+msgstr "Mouse Support"
 
 #. type: section
 #: sed-out/magit.texi:96 sed-out/magit.texi:127 sed-out/magit.texi:709
@@ -271,36 +298,40 @@ msgstr "Mouse Support::"
 msgid "Running Git"
 msgstr "Running Git"
 
-#. type: section
-#: sed-out/magit.texi:98 sed-out/magit.texi:711 sed-out/magit.texi:712
+#. type: subsection
+#: sed-out/magit.texi:105 sed-out/magit.texi:753 sed-out/magit.texi:755
+#: sed-out/magit.texi:756
 #, no-wrap
-msgid "Modes and Buffers"
-msgstr "Modes and Buffers"
+msgid "Switching Buffers"
+msgstr "バッファの切り替え"
 
-#. type: menuentry
-#: sed-out/magit.texi:105 sed-out/magit.texi:753
-msgid "Switching Buffers::"
-msgstr "バッファの切り替え::"
+#. type: subsection
+#: sed-out/magit.texi:105 sed-out/magit.texi:753 sed-out/magit.texi:860
+#: sed-out/magit.texi:861
+#, no-wrap
+msgid "Naming Buffers"
+msgstr "バッファの名付け"
 
-#. type: menuentry
-#: sed-out/magit.texi:105 sed-out/magit.texi:753
-msgid "Naming Buffers::"
-msgstr "バッファの名付け::"
+#. type: subsection
+#: sed-out/magit.texi:105 sed-out/magit.texi:753 sed-out/magit.texi:951
+#: sed-out/magit.texi:952
+#, no-wrap
+msgid "Quitting Windows"
+msgstr "Quitting Windows"
 
-#. type: menuentry
-#: sed-out/magit.texi:105 sed-out/magit.texi:753
-msgid "Quitting Windows::"
-msgstr "Quitting Windows::"
+#. type: subsection
+#: sed-out/magit.texi:105 sed-out/magit.texi:753 sed-out/magit.texi:995
+#: sed-out/magit.texi:996
+#, no-wrap
+msgid "Automatic Refreshing of Magit Buffers"
+msgstr "Automatic Refreshing of Magit Buffers"
 
-#. type: menuentry
-#: sed-out/magit.texi:105 sed-out/magit.texi:753
-msgid "Automatic Refreshing of Magit Buffers::"
-msgstr "Automatic Refreshing of Magit Buffers::"
-
-#. type: menuentry
-#: sed-out/magit.texi:105 sed-out/magit.texi:753
-msgid "Automatic Saving of File-Visiting Buffers::"
-msgstr "Automatic Saving of File-Visiting Buffers::"
+#. type: subsection
+#: sed-out/magit.texi:105 sed-out/magit.texi:753 sed-out/magit.texi:1066
+#: sed-out/magit.texi:1067
+#, no-wrap
+msgid "Automatic Saving of File-Visiting Buffers"
+msgstr "Automatic Saving of File-Visiting Buffers"
 
 #. type: subsection
 #: sed-out/magit.texi:105 sed-out/magit.texi:753 sed-out/magit.texi:1087
@@ -309,31 +340,33 @@ msgstr "Automatic Saving of File-Visiting Buffers::"
 msgid "Automatic Reverting of File-Visiting Buffers"
 msgstr "Automatic Reverting of File-Visiting Buffers"
 
-#. type: section
-#: sed-out/magit.texi:108 sed-out/magit.texi:1240 sed-out/magit.texi:1241
+#. type: subsection
+#: sed-out/magit.texi:114 sed-out/magit.texi:1262 sed-out/magit.texi:1264
+#: sed-out/magit.texi:1265
 #, no-wrap
-msgid "Sections"
-msgstr "Sections"
+msgid "Section Movement"
+msgstr "Section Movement"
 
-#. type: menuentry
-#: sed-out/magit.texi:114 sed-out/magit.texi:1262
-msgid "Section Movement::"
-msgstr "Section Movement::"
+#. type: subsection
+#: sed-out/magit.texi:114 sed-out/magit.texi:1262 sed-out/magit.texi:1397
+#: sed-out/magit.texi:1398
+#, no-wrap
+msgid "Section Visibility"
+msgstr "Section Visibility"
 
-#. type: menuentry
-#: sed-out/magit.texi:114 sed-out/magit.texi:1262
-msgid "Section Visibility::"
-msgstr "Section Visibility::"
+#. type: subsection
+#: sed-out/magit.texi:114 sed-out/magit.texi:1262 sed-out/magit.texi:1570
+#: sed-out/magit.texi:1571
+#, no-wrap
+msgid "Section Hooks"
+msgstr "Section Hooks"
 
-#. type: menuentry
-#: sed-out/magit.texi:114 sed-out/magit.texi:1262
-msgid "Section Hooks::"
-msgstr "Section Hooks::"
-
-#. type: menuentry
-#: sed-out/magit.texi:114 sed-out/magit.texi:1262
-msgid "Section Types and Values::"
-msgstr "Section Types and Values::"
+#. type: subsection
+#: sed-out/magit.texi:114 sed-out/magit.texi:1262 sed-out/magit.texi:1616
+#: sed-out/magit.texi:1617
+#, no-wrap
+msgid "Section Types and Values"
+msgstr "Section Types and Values"
 
 #. type: subsection
 #: sed-out/magit.texi:114 sed-out/magit.texi:1262 sed-out/magit.texi:1651
@@ -348,30 +381,40 @@ msgstr "Section Options"
 msgid "Completion, Confirmation and the Selection"
 msgstr "Completion(補完)とConfirmation(確認)とSelection(選択範囲)"
 
-#. type: menuentry
-#: sed-out/magit.texi:124 sed-out/magit.texi:1847
-msgid "Action Confirmation::"
-msgstr "アクションの確認::"
+#. type: subsection
+#: sed-out/magit.texi:124 sed-out/magit.texi:1847 sed-out/magit.texi:1849
+#: sed-out/magit.texi:1850
+#, no-wrap
+msgid "Action Confirmation"
+msgstr "アクションの確認"
 
-#. type: menuentry
-#: sed-out/magit.texi:124 sed-out/magit.texi:1847
-msgid "Completion and Confirmation::"
-msgstr "補完と確認::"
+#. type: subsection
+#: sed-out/magit.texi:124 sed-out/magit.texi:1847 sed-out/magit.texi:2043
+#: sed-out/magit.texi:2044
+#, no-wrap
+msgid "Completion and Confirmation"
+msgstr "補完と確認"
 
-#. type: menuentry
-#: sed-out/magit.texi:124 sed-out/magit.texi:1847
-msgid "The Selection::"
-msgstr "選択範囲::"
+#. type: subsection
+#: sed-out/magit.texi:124 sed-out/magit.texi:1847 sed-out/magit.texi:2110
+#: sed-out/magit.texi:2111
+#, no-wrap
+msgid "The Selection"
+msgstr "選択範囲"
 
-#. type: menuentry
-#: sed-out/magit.texi:124 sed-out/magit.texi:1847
-msgid "The hunk-internal region::"
-msgstr "ハンク内部リージョン::"
+#. type: subsection
+#: sed-out/magit.texi:124 sed-out/magit.texi:1847 sed-out/magit.texi:2165
+#: sed-out/magit.texi:2166
+#, no-wrap
+msgid "The hunk-internal region"
+msgstr "ハンク内部リージョン"
 
-#. type: menuentry
-#: sed-out/magit.texi:124 sed-out/magit.texi:1847
-msgid "Support for Completion Frameworks::"
-msgstr "補完フレームワークのサポート::"
+#. type: subsection
+#: sed-out/magit.texi:124 sed-out/magit.texi:1847 sed-out/magit.texi:2186
+#: sed-out/magit.texi:2187
+#, no-wrap
+msgid "Support for Completion Frameworks"
+msgstr "補完フレームワークのサポート"
 
 #. type: subsection
 #: sed-out/magit.texi:124 sed-out/magit.texi:1847 sed-out/magit.texi:2287
@@ -380,25 +423,33 @@ msgstr "補完フレームワークのサポート::"
 msgid "Additional Completion Options"
 msgstr "追加の補完オプション"
 
-#. type: menuentry
-#: sed-out/magit.texi:133 sed-out/magit.texi:2318
-msgid "Viewing Git Output::"
-msgstr "Viewing Git Output::"
+#. type: subsection
+#: sed-out/magit.texi:133 sed-out/magit.texi:2318 sed-out/magit.texi:2320
+#: sed-out/magit.texi:2321
+#, no-wrap
+msgid "Viewing Git Output"
+msgstr "Viewing Git Output"
 
-#. type: menuentry
-#: sed-out/magit.texi:133 sed-out/magit.texi:2318
-msgid "Git Process Status::"
-msgstr "Git Process Status::"
+#. type: subsection
+#: sed-out/magit.texi:133 sed-out/magit.texi:2318 sed-out/magit.texi:2392
+#: sed-out/magit.texi:2393
+#, no-wrap
+msgid "Git Process Status"
+msgstr "Git Process Status"
 
-#. type: menuentry
-#: sed-out/magit.texi:133 sed-out/magit.texi:2318
-msgid "Running Git Manually::"
-msgstr "Gitを手動で実行::"
+#. type: subsection
+#: sed-out/magit.texi:133 sed-out/magit.texi:2318 sed-out/magit.texi:2413
+#: sed-out/magit.texi:2414
+#, no-wrap
+msgid "Running Git Manually"
+msgstr "Gitを手動で実行"
 
-#. type: menuentry
-#: sed-out/magit.texi:133 sed-out/magit.texi:2318
-msgid "Git Executable::"
-msgstr "Git実行ファイル::"
+#. type: subsection
+#: sed-out/magit.texi:133 sed-out/magit.texi:2318 sed-out/magit.texi:2501
+#: sed-out/magit.texi:2502
+#, no-wrap
+msgid "Git Executable"
+msgstr "Git実行ファイル"
 
 #. type: subsection
 #: sed-out/magit.texi:133 sed-out/magit.texi:2318 sed-out/magit.texi:2566
@@ -407,51 +458,61 @@ msgstr "Git実行ファイル::"
 msgid "Global Git Arguments"
 msgstr "Global Git Arguments"
 
-#. type: chapter
-#: sed-out/magit.texi:136 sed-out/magit.texi:2593 sed-out/magit.texi:2594
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:148 sed-out/magit.texi:2622
+#: sed-out/magit.texi:2624 sed-out/magit.texi:2625
 #, no-wrap
-msgid "Inspecting"
-msgstr "Inspecting"
+msgid "Status Buffer"
+msgstr "Status Buffer"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Status Buffer::"
-msgstr "Status Buffer::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:2622 sed-out/magit.texi:3102
+#: sed-out/magit.texi:3103
+#, no-wrap
+msgid "Repository List"
+msgstr "Repository List"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Repository List::"
-msgstr "Repository List::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:156 sed-out/magit.texi:2622
+#: sed-out/magit.texi:3245 sed-out/magit.texi:3246
+#, no-wrap
+msgid "Logging"
+msgstr "Logging"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Logging::"
-msgstr "Logging::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:166 sed-out/magit.texi:2622
+#: sed-out/magit.texi:3785 sed-out/magit.texi:3786
+#, no-wrap
+msgid "Diffing"
+msgstr "Diffing"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Diffing::"
-msgstr "Diffing::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:2622 sed-out/magit.texi:4319
+#: sed-out/magit.texi:4320
+#, no-wrap
+msgid "Ediffing"
+msgstr "Ediffing"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Ediffing::"
-msgstr "Ediffing::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:174 sed-out/magit.texi:2622
+#: sed-out/magit.texi:4477 sed-out/magit.texi:4478
+#, no-wrap
+msgid "References Buffer"
+msgstr "References Buffer"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "References Buffer::"
-msgstr "References Buffer::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:2622 sed-out/magit.texi:4784
+#: sed-out/magit.texi:4785
+#, no-wrap
+msgid "Bisecting"
+msgstr "Bisecting"
 
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Bisecting::"
-msgstr "Bisecting::"
-
-#. type: menuentry
-#: sed-out/magit.texi:146 sed-out/magit.texi:2622
-msgid "Visiting Files and Blobs::"
-msgstr "Visiting Files and Blobs::"
+#. type: section
+#: sed-out/magit.texi:146 sed-out/magit.texi:179 sed-out/magit.texi:2622
+#: sed-out/magit.texi:4876 sed-out/magit.texi:4877
+#, no-wrap
+msgid "Visiting Files and Blobs"
+msgstr "Visiting Files and Blobs"
 
 #. type: section
 #: sed-out/magit.texi:146 sed-out/magit.texi:2622 sed-out/magit.texi:5003
@@ -460,26 +521,26 @@ msgstr "Visiting Files and Blobs::"
 msgid "Blaming"
 msgstr "Blaming"
 
-#. type: section
-#: sed-out/magit.texi:148 sed-out/magit.texi:2624 sed-out/magit.texi:2625
+#. type: subsection
+#: sed-out/magit.texi:153 sed-out/magit.texi:2763 sed-out/magit.texi:2765
+#: sed-out/magit.texi:2766
 #, no-wrap
-msgid "Status Buffer"
-msgstr "Status Buffer"
+msgid "Status Sections"
+msgstr "Status Sections"
 
-#. type: menuentry
-#: sed-out/magit.texi:153 sed-out/magit.texi:2763
-msgid "Status Sections::"
-msgstr "Status Sections::"
+#. type: subsection
+#: sed-out/magit.texi:153 sed-out/magit.texi:2763 sed-out/magit.texi:2925
+#: sed-out/magit.texi:2926
+#, no-wrap
+msgid "Status Header Sections"
+msgstr "Status Header Sections"
 
-#. type: menuentry
-#: sed-out/magit.texi:153 sed-out/magit.texi:2763
-msgid "Status Header Sections::"
-msgstr "Status Header Sections::"
-
-#. type: menuentry
-#: sed-out/magit.texi:153 sed-out/magit.texi:2763
-msgid "Status Module Sections::"
-msgstr "Status Module Sections::"
+#. type: subsection
+#: sed-out/magit.texi:153 sed-out/magit.texi:2763 sed-out/magit.texi:3000
+#: sed-out/magit.texi:3001
+#, no-wrap
+msgid "Status Module Sections"
+msgstr "Status Module Sections"
 
 #. type: subsection
 #: sed-out/magit.texi:153 sed-out/magit.texi:2763 sed-out/magit.texi:3064
@@ -488,36 +549,40 @@ msgstr "Status Module Sections::"
 msgid "Status Options"
 msgstr "Status Options"
 
-#. type: section
-#: sed-out/magit.texi:156 sed-out/magit.texi:3245 sed-out/magit.texi:3246
+#. type: subsection
+#: sed-out/magit.texi:163 sed-out/magit.texi:3341 sed-out/magit.texi:3343
+#: sed-out/magit.texi:3344
 #, no-wrap
-msgid "Logging"
-msgstr "Logging"
+msgid "Refreshing Logs"
+msgstr "Refreshing Logs"
 
-#. type: menuentry
-#: sed-out/magit.texi:163 sed-out/magit.texi:3341
-msgid "Refreshing Logs::"
-msgstr "Refreshing Logs::"
+#. type: subsection
+#: sed-out/magit.texi:163 sed-out/magit.texi:3341 sed-out/magit.texi:3387
+#: sed-out/magit.texi:3388
+#, no-wrap
+msgid "Log Buffer"
+msgstr "Log Buffer"
 
-#. type: menuentry
-#: sed-out/magit.texi:163 sed-out/magit.texi:3341
-msgid "Log Buffer::"
-msgstr "Log Buffer::"
+#. type: subsection
+#: sed-out/magit.texi:163 sed-out/magit.texi:3341 sed-out/magit.texi:3518
+#: sed-out/magit.texi:3519
+#, no-wrap
+msgid "Log Margin"
+msgstr "Log Margin"
 
-#. type: menuentry
-#: sed-out/magit.texi:163 sed-out/magit.texi:3341
-msgid "Log Margin::"
-msgstr "Log Margin::"
+#. type: subsection
+#: sed-out/magit.texi:163 sed-out/magit.texi:3341 sed-out/magit.texi:3601
+#: sed-out/magit.texi:3602
+#, no-wrap
+msgid "Select from Log"
+msgstr "Select from Log"
 
-#. type: menuentry
-#: sed-out/magit.texi:163 sed-out/magit.texi:3341
-msgid "Select from Log::"
-msgstr "Select from Log::"
-
-#. type: menuentry
-#: sed-out/magit.texi:163 sed-out/magit.texi:3341
-msgid "Reflog::"
-msgstr "Reflog::"
+#. type: subsection
+#: sed-out/magit.texi:163 sed-out/magit.texi:3341 sed-out/magit.texi:3660
+#: sed-out/magit.texi:3661
+#, no-wrap
+msgid "Reflog"
+msgstr "Reflog"
 
 #. type: subsection
 #: sed-out/magit.texi:163 sed-out/magit.texi:3341 sed-out/magit.texi:3724
@@ -526,26 +591,26 @@ msgstr "Reflog::"
 msgid "Cherries"
 msgstr "Cherries"
 
-#. type: section
-#: sed-out/magit.texi:166 sed-out/magit.texi:3785 sed-out/magit.texi:3786
+#. type: subsection
+#: sed-out/magit.texi:171 sed-out/magit.texi:3891 sed-out/magit.texi:3893
+#: sed-out/magit.texi:3894
 #, no-wrap
-msgid "Diffing"
-msgstr "Diffing"
+msgid "Refreshing Diffs"
+msgstr "Refreshing Diffs"
 
-#. type: menuentry
-#: sed-out/magit.texi:171 sed-out/magit.texi:3891
-msgid "Refreshing Diffs::"
-msgstr "Refreshing Diffs::"
+#. type: subsection
+#: sed-out/magit.texi:171 sed-out/magit.texi:3891 sed-out/magit.texi:4007
+#: sed-out/magit.texi:4008
+#, no-wrap
+msgid "Commands Available in Diffs"
+msgstr "Commands Available in Diffs"
 
-#. type: menuentry
-#: sed-out/magit.texi:171 sed-out/magit.texi:3891
-msgid "Commands Available in Diffs::"
-msgstr "Commands Available in Diffs::"
-
-#. type: menuentry
-#: sed-out/magit.texi:171 sed-out/magit.texi:3891
-msgid "Diff Options::"
-msgstr "Diff Options::"
+#. type: subsection
+#: sed-out/magit.texi:171 sed-out/magit.texi:3891 sed-out/magit.texi:4078
+#: sed-out/magit.texi:4079
+#, no-wrap
+msgid "Diff Options"
+msgstr "Diff Options"
 
 #. type: subsection
 #: sed-out/magit.texi:171 sed-out/magit.texi:3891 sed-out/magit.texi:4237
@@ -554,12 +619,6 @@ msgstr "Diff Options::"
 msgid "Revision Buffer"
 msgstr "Revision Buffer"
 
-#. type: section
-#: sed-out/magit.texi:174 sed-out/magit.texi:4477 sed-out/magit.texi:4478
-#, no-wrap
-msgid "References Buffer"
-msgstr "References Buffer"
-
 #. type: subsection
 #: sed-out/magit.texi:176 sed-out/magit.texi:4756 sed-out/magit.texi:4758
 #: sed-out/magit.texi:4759
@@ -567,16 +626,12 @@ msgstr "References Buffer"
 msgid "References Sections"
 msgstr "References Sections"
 
-#. type: section
-#: sed-out/magit.texi:179 sed-out/magit.texi:4876 sed-out/magit.texi:4877
+#. type: subsection
+#: sed-out/magit.texi:182 sed-out/magit.texi:4887 sed-out/magit.texi:4889
+#: sed-out/magit.texi:4890
 #, no-wrap
-msgid "Visiting Files and Blobs"
-msgstr "Visiting Files and Blobs"
-
-#. type: menuentry
-#: sed-out/magit.texi:182 sed-out/magit.texi:4887
-msgid "General-Purpose Visit Commands::"
-msgstr "General-Purpose Visit Commands::"
+msgid "General-Purpose Visit Commands"
+msgstr "General-Purpose Visit Commands"
 
 #. type: subsection
 #: sed-out/magit.texi:182 sed-out/magit.texi:4887 sed-out/magit.texi:4914
@@ -585,66 +640,83 @@ msgstr "General-Purpose Visit Commands::"
 msgid "Visiting Files and Blobs from a Diff"
 msgstr "Visiting Files and Blobs from a Diff"
 
-#. type: chapter
-#: sed-out/magit.texi:185 sed-out/magit.texi:5211 sed-out/magit.texi:5212
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:5229
+#: sed-out/magit.texi:5230
 #, no-wrap
-msgid "Manipulating"
-msgstr "Manipulating"
+msgid "Creating Repository"
+msgstr "Creating Repository"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Creating Repository::"
-msgstr "Creating Repository::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:5245
+#: sed-out/magit.texi:5246
+#, no-wrap
+msgid "Cloning Repository"
+msgstr "Cloning Repository"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Cloning Repository::"
-msgstr "Cloning Repository::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:200 sed-out/magit.texi:5227
+#: sed-out/magit.texi:5414 sed-out/magit.texi:5415
+#, no-wrap
+msgid "Staging and Unstaging"
+msgstr "Staging and Unstaging"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Staging and Unstaging::"
-msgstr "Staging and Unstaging::"
+# git apply : (どこかで作った) patch を当てる
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:5544
+#: sed-out/magit.texi:5545
+#, no-wrap
+msgid "Applying"
+msgstr "Applying"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Applying::"
-msgstr "Applying::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:205 sed-out/magit.texi:5227
+#: sed-out/magit.texi:5610 sed-out/magit.texi:5611
+#, no-wrap
+msgid "Committing"
+msgstr "Committing"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Committing::"
-msgstr "Committing::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:211 sed-out/magit.texi:5227
+#: sed-out/magit.texi:6108 sed-out/magit.texi:6109
+#, no-wrap
+msgid "Branching"
+msgstr "Branching"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Branching::"
-msgstr "Branching::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:6697
+#: sed-out/magit.texi:6698
+#, no-wrap
+msgid "Merging"
+msgstr "Merging"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Merging::"
-msgstr "Merging::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:6816
+#: sed-out/magit.texi:6817
+#, no-wrap
+msgid "Resolving Conflicts"
+msgstr "Resolving Conflicts"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Resolving Conflicts::"
-msgstr "Resolving Conflicts::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:219 sed-out/magit.texi:5227
+#: sed-out/magit.texi:6937 sed-out/magit.texi:6938
+#, no-wrap
+msgid "Rebasing"
+msgstr "Rebasing"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Rebasing::"
-msgstr "Rebasing::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:225 sed-out/magit.texi:5227
+#: sed-out/magit.texi:7473 sed-out/magit.texi:7474
+#, no-wrap
+msgid "Cherry Picking"
+msgstr "Cherry Picking"
 
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Cherry Picking::"
-msgstr "Cherry Picking::"
-
-#. type: menuentry
-#: sed-out/magit.texi:198 sed-out/magit.texi:5227
-msgid "Resetting::"
-msgstr "Resetting::"
+#. type: section
+#: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:7660
+#: sed-out/magit.texi:7661
+#, no-wrap
+msgid "Resetting"
+msgstr "Resetting"
 
 #. type: section
 #: sed-out/magit.texi:198 sed-out/magit.texi:5227 sed-out/magit.texi:7732
@@ -653,12 +725,6 @@ msgstr "Resetting::"
 msgid "Stashing"
 msgstr "Stashing"
 
-#. type: section
-#: sed-out/magit.texi:200 sed-out/magit.texi:5414 sed-out/magit.texi:5415
-#, no-wrap
-msgid "Staging and Unstaging"
-msgstr "Staging and Unstaging"
-
 #. type: subsection
 #: sed-out/magit.texi:202 sed-out/magit.texi:5517 sed-out/magit.texi:5519
 #: sed-out/magit.texi:5520
@@ -666,16 +732,12 @@ msgstr "Staging and Unstaging"
 msgid "Staging from File-Visiting Buffers"
 msgstr "Staging from File-Visiting Buffers"
 
-#. type: section
-#: sed-out/magit.texi:205 sed-out/magit.texi:5610 sed-out/magit.texi:5611
+#. type: subsection
+#: sed-out/magit.texi:208 sed-out/magit.texi:5623 sed-out/magit.texi:5625
+#: sed-out/magit.texi:5626
 #, no-wrap
-msgid "Committing"
-msgstr "Committing"
-
-#. type: menuentry
-#: sed-out/magit.texi:208 sed-out/magit.texi:5623
-msgid "Initiating a Commit::"
-msgstr "コミット開始::"
+msgid "Initiating a Commit"
+msgstr "コミット開始"
 
 #. type: subsection
 #: sed-out/magit.texi:208 sed-out/magit.texi:5623 sed-out/magit.texi:5784
@@ -684,26 +746,26 @@ msgstr "コミット開始::"
 msgid "Editing Commit Messages"
 msgstr "Editing Commit Messages"
 
-#. type: section
-#: sed-out/magit.texi:211 sed-out/magit.texi:6108 sed-out/magit.texi:6109
+#. type: subsection
+#: sed-out/magit.texi:216 sed-out/magit.texi:6116 sed-out/magit.texi:6118
+#: sed-out/magit.texi:6119
 #, no-wrap
-msgid "Branching"
-msgstr "Branching"
+msgid "The Two Remotes"
+msgstr "The Two Remotes"
 
-#. type: menuentry
-#: sed-out/magit.texi:216 sed-out/magit.texi:6116
-msgid "The Two Remotes::"
-msgstr "The Two Remotes::"
+#. type: subsection
+#: sed-out/magit.texi:216 sed-out/magit.texi:6116 sed-out/magit.texi:6165
+#: sed-out/magit.texi:6166
+#, no-wrap
+msgid "Branch Commands"
+msgstr "Branch Commands"
 
-#. type: menuentry
-#: sed-out/magit.texi:216 sed-out/magit.texi:6116
-msgid "Branch Commands::"
-msgstr "Branch Commands::"
-
-#. type: menuentry
-#: sed-out/magit.texi:216 sed-out/magit.texi:6116
-msgid "Branch Git Variables::"
-msgstr "Branch Git Variables::"
+#. type: subsection
+#: sed-out/magit.texi:216 sed-out/magit.texi:6116 sed-out/magit.texi:6491
+#: sed-out/magit.texi:6492
+#, no-wrap
+msgid "Branch Git Variables"
+msgstr "Branch Git Variables"
 
 #. type: subsection
 #: sed-out/magit.texi:216 sed-out/magit.texi:6116 sed-out/magit.texi:6672
@@ -712,16 +774,12 @@ msgstr "Branch Git Variables::"
 msgid "Auxiliary Branch Commands"
 msgstr "Auxiliary Branch Commands"
 
-#. type: section
-#: sed-out/magit.texi:219 sed-out/magit.texi:6937 sed-out/magit.texi:6938
+#. type: subsection
+#: sed-out/magit.texi:222 sed-out/magit.texi:7098 sed-out/magit.texi:7100
+#: sed-out/magit.texi:7101
 #, no-wrap
-msgid "Rebasing"
-msgstr "Rebasing"
-
-#. type: menuentry
-#: sed-out/magit.texi:222 sed-out/magit.texi:7098
-msgid "Editing Rebase Sequences::"
-msgstr "Editing Rebase Sequences::"
+msgid "Editing Rebase Sequences"
+msgstr "Editing Rebase Sequences"
 
 #. type: subsection
 #: sed-out/magit.texi:222 sed-out/magit.texi:7098 sed-out/magit.texi:7264
@@ -730,12 +788,6 @@ msgstr "Editing Rebase Sequences::"
 msgid "Information About In-Progress Rebase"
 msgstr "Information About In-Progress Rebase"
 
-#. type: section
-#: sed-out/magit.texi:225 sed-out/magit.texi:7473 sed-out/magit.texi:7474
-#, no-wrap
-msgid "Cherry Picking"
-msgstr "Cherry Picking"
-
 #. type: subsection
 #: sed-out/magit.texi:227 sed-out/magit.texi:7605 sed-out/magit.texi:7607
 #: sed-out/magit.texi:7608
@@ -743,36 +795,40 @@ msgstr "Cherry Picking"
 msgid "Reverting"
 msgstr "Reverting"
 
-#. type: chapter
-#: sed-out/magit.texi:230 sed-out/magit.texi:7891 sed-out/magit.texi:7892
+#. type: section
+#: sed-out/magit.texi:237 sed-out/magit.texi:239 sed-out/magit.texi:7901
+#: sed-out/magit.texi:7903 sed-out/magit.texi:7904
 #, no-wrap
-msgid "Transferring"
-msgstr "Transferring"
+msgid "Remotes"
+msgstr "Remotes"
 
-#. type: menuentry
-#: sed-out/magit.texi:237 sed-out/magit.texi:7901
-msgid "Remotes::"
-msgstr "Remotes::"
+#. type: section
+#: sed-out/magit.texi:237 sed-out/magit.texi:7901 sed-out/magit.texi:8071
+#: sed-out/magit.texi:8072
+#, no-wrap
+msgid "Fetching"
+msgstr "Fetching"
 
-#. type: menuentry
-#: sed-out/magit.texi:237 sed-out/magit.texi:7901
-msgid "Fetching::"
-msgstr "Fetching::"
+#. type: section
+#: sed-out/magit.texi:237 sed-out/magit.texi:7901 sed-out/magit.texi:8164
+#: sed-out/magit.texi:8165
+#, no-wrap
+msgid "Pulling"
+msgstr "Pulling"
 
-#. type: menuentry
-#: sed-out/magit.texi:237 sed-out/magit.texi:7901
-msgid "Pulling::"
-msgstr "Pulling::"
+#. type: section
+#: sed-out/magit.texi:237 sed-out/magit.texi:7901 sed-out/magit.texi:8213
+#: sed-out/magit.texi:8214
+#, no-wrap
+msgid "Pushing"
+msgstr "Pushing"
 
-#. type: menuentry
-#: sed-out/magit.texi:237 sed-out/magit.texi:7901
-msgid "Pushing::"
-msgstr "Pushing::"
-
-#. type: menuentry
-#: sed-out/magit.texi:237 sed-out/magit.texi:7901
-msgid "Plain Patches::"
-msgstr "Plain Patches::"
+#. type: section
+#: sed-out/magit.texi:237 sed-out/magit.texi:7901 sed-out/magit.texi:8349
+#: sed-out/magit.texi:8350
+#, no-wrap
+msgid "Plain Patches"
+msgstr "Plain Patches"
 
 #. type: section
 #: sed-out/magit.texi:237 sed-out/magit.texi:7901 sed-out/magit.texi:8390
@@ -781,16 +837,12 @@ msgstr "Plain Patches::"
 msgid "Maildir Patches"
 msgstr "Maildir Patches"
 
-#. type: section
-#: sed-out/magit.texi:239 sed-out/magit.texi:7903 sed-out/magit.texi:7904
+#. type: subsection
+#: sed-out/magit.texi:242 sed-out/magit.texi:7909 sed-out/magit.texi:7911
+#: sed-out/magit.texi:7912
 #, no-wrap
-msgid "Remotes"
-msgstr "Remotes"
-
-#. type: menuentry
-#: sed-out/magit.texi:242 sed-out/magit.texi:7909
-msgid "Remote Commands::"
-msgstr "Remote Commands::"
+msgid "Remote Commands"
+msgstr "Remote Commands"
 
 #. type: subsection
 #: sed-out/magit.texi:242 sed-out/magit.texi:7909 sed-out/magit.texi:8036
@@ -799,61 +851,79 @@ msgstr "Remote Commands::"
 msgid "Remote Git Variables"
 msgstr "Remote Git Variables"
 
-#. type: chapter
-#: sed-out/magit.texi:245 sed-out/magit.texi:8469 sed-out/magit.texi:8470
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:8486
+#: sed-out/magit.texi:8487
 #, no-wrap
-msgid "Miscellaneous"
-msgstr "Miscellaneous"
+msgid "Tagging"
+msgstr "Tagging"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Tagging::"
-msgstr "Tagging::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:8552
+#: sed-out/magit.texi:8553
+#, no-wrap
+msgid "Notes"
+msgstr "Notes"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Notes::"
-msgstr "Notes::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:259 sed-out/magit.texi:8484
+#: sed-out/magit.texi:8645 sed-out/magit.texi:8646
+#, no-wrap
+msgid "Submodules"
+msgstr "Submodules"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Submodules::"
-msgstr "Submodules::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:8785
+#: sed-out/magit.texi:8786
+#, no-wrap
+msgid "Subtree"
+msgstr "Subtree"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Subtree::"
-msgstr "Subtree::"
+# https://qiita.com/yoichi22/items/8f92110f24690ca8966f
+# git worktree を使うと、一つのローカルリポジトリで作業ツリーを複数同時に持てる。
+# このコマンドは Git 2.5.0 から導入されている。
+# Git - git-worktree Documentation
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:8866
+#: sed-out/magit.texi:8867
+#, no-wrap
+msgid "Worktree"
+msgstr "Worktree"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Worktree::"
-msgstr "Worktree::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:8920
+#: sed-out/magit.texi:8921
+#, no-wrap
+msgid "Sparse checkouts"
+msgstr "Sparse checkouts"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Sparse checkouts::"
-msgstr "Sparse checkouts::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:9003
+#: sed-out/magit.texi:9004
+#, no-wrap
+msgid "Bundle"
+msgstr "Bundle"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Bundle::"
-msgstr "Bundle::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:9025
+#: sed-out/magit.texi:9026
+#, no-wrap
+msgid "Common Commands"
+msgstr "Common Commands"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Common Commands::"
-msgstr "Common Commands::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:265 sed-out/magit.texi:8484
+#: sed-out/magit.texi:9087 sed-out/magit.texi:9088
+#, no-wrap
+msgid "Wip Modes"
+msgstr "Wip Modes"
 
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Wip Modes::"
-msgstr "Wip Modes::"
-
-#. type: menuentry
-#: sed-out/magit.texi:257 sed-out/magit.texi:8484
-msgid "Commands for Buffers Visiting Files::"
-msgstr "Commands for Buffers Visiting Files::"
+#. type: section
+#: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:9332
+#: sed-out/magit.texi:9333
+#, no-wrap
+msgid "Commands for Buffers Visiting Files"
+msgstr "Commands for Buffers Visiting Files"
 
 #. type: section
 #: sed-out/magit.texi:257 sed-out/magit.texi:8484 sed-out/magit.texi:9494
@@ -862,16 +932,12 @@ msgstr "Commands for Buffers Visiting Files::"
 msgid "Minor Mode for Buffers Visiting Blobs"
 msgstr "Minor Mode for Buffers Visiting Blobs"
 
-#. type: section
-#: sed-out/magit.texi:259 sed-out/magit.texi:8645 sed-out/magit.texi:8646
+#. type: subsection
+#: sed-out/magit.texi:262 sed-out/magit.texi:8664 sed-out/magit.texi:8666
+#: sed-out/magit.texi:8667
 #, no-wrap
-msgid "Submodules"
-msgstr "Submodules"
-
-#. type: menuentry
-#: sed-out/magit.texi:262 sed-out/magit.texi:8664
-msgid "Listing Submodules::"
-msgstr "Listing Submodules::"
+msgid "Listing Submodules"
+msgstr "Listing Submodules"
 
 #. type: subsection
 #: sed-out/magit.texi:262 sed-out/magit.texi:8664 sed-out/magit.texi:8709
@@ -880,16 +946,12 @@ msgstr "Listing Submodules::"
 msgid "Submodule Transient"
 msgstr "submodule用トランジェントコマンド"
 
-#. type: section
-#: sed-out/magit.texi:265 sed-out/magit.texi:9087 sed-out/magit.texi:9088
+#. type: subsection
+#: sed-out/magit.texi:268 sed-out/magit.texi:9199 sed-out/magit.texi:9201
+#: sed-out/magit.texi:9202
 #, no-wrap
-msgid "Wip Modes"
-msgstr "Wip Modes"
-
-#. type: menuentry
-#: sed-out/magit.texi:268 sed-out/magit.texi:9199
-msgid "Wip Graph::"
-msgstr "Wip Graph::"
+msgid "Wip Graph"
+msgstr "Wip Graph"
 
 #. type: subsection
 #: sed-out/magit.texi:268 sed-out/magit.texi:9199 sed-out/magit.texi:9264
@@ -898,16 +960,12 @@ msgstr "Wip Graph::"
 msgid "Legacy Wip Modes"
 msgstr "Legacy Wip Modes"
 
-#. type: chapter
-#: sed-out/magit.texi:271 sed-out/magit.texi:9520 sed-out/magit.texi:9521
+#. type: section
+#: sed-out/magit.texi:274 sed-out/magit.texi:9557 sed-out/magit.texi:9559
+#: sed-out/magit.texi:9560
 #, no-wrap
-msgid "Customizing"
-msgstr "Customizing"
-
-#. type: menuentry
-#: sed-out/magit.texi:274 sed-out/magit.texi:9557
-msgid "Per-Repository Configuration::"
-msgstr "Per-Repository Configuration::"
+msgid "Per-Repository Configuration"
+msgstr "Per-Repository Configuration"
 
 #. type: section
 #: sed-out/magit.texi:274 sed-out/magit.texi:276 sed-out/magit.texi:9557
@@ -916,15 +974,19 @@ msgstr "Per-Repository Configuration::"
 msgid "Essential Settings"
 msgstr "基本設定"
 
-#. type: menuentry
-#: sed-out/magit.texi:280 sed-out/magit.texi:9661
-msgid "Safety::"
-msgstr "Safety::"
+#. type: subsection
+#: sed-out/magit.texi:280 sed-out/magit.texi:9661 sed-out/magit.texi:9663
+#: sed-out/magit.texi:9664
+#, no-wrap
+msgid "Safety"
+msgstr "Safety"
 
-#. type: menuentry
-#: sed-out/magit.texi:280 sed-out/magit.texi:9661
-msgid "Performance::"
-msgstr "Performance::"
+#. type: subsection
+#: sed-out/magit.texi:280 sed-out/magit.texi:9661 sed-out/magit.texi:9695
+#: sed-out/magit.texi:9696
+#, no-wrap
+msgid "Performance"
+msgstr "Performance"
 
 #. type: subsection
 #: sed-out/magit.texi:280 sed-out/magit.texi:9661 sed-out/magit.texi:9897
@@ -933,26 +995,26 @@ msgstr "Performance::"
 msgid "Default Bindings"
 msgstr "Default Bindings"
 
-#. type: chapter
-#: sed-out/magit.texi:283 sed-out/magit.texi:9952 sed-out/magit.texi:9953
+#. type: section
+#: sed-out/magit.texi:288 sed-out/magit.texi:290 sed-out/magit.texi:9972
+#: sed-out/magit.texi:9974 sed-out/magit.texi:9975
 #, no-wrap
-msgid "Plumbing"
-msgstr "配管コマンド(Plumbing)"
+msgid "Calling Git"
+msgstr "Calling Git"
 
-#. type: menuentry
-#: sed-out/magit.texi:288 sed-out/magit.texi:9972
-msgid "Calling Git::"
-msgstr "Calling Git::"
+#. type: section
+#: sed-out/magit.texi:288 sed-out/magit.texi:296 sed-out/magit.texi:9972
+#: sed-out/magit.texi:10236 sed-out/magit.texi:10237
+#, no-wrap
+msgid "Section Plumbing"
+msgstr "Section Plumbing"
 
-#. type: menuentry
-#: sed-out/magit.texi:288 sed-out/magit.texi:9972
-msgid "Section Plumbing::"
-msgstr "Section Plumbing::"
-
-#. type: menuentry
-#: sed-out/magit.texi:288 sed-out/magit.texi:9972
-msgid "Refreshing Buffers::"
-msgstr "Refreshing Buffers::"
+#. type: section
+#: sed-out/magit.texi:288 sed-out/magit.texi:9972 sed-out/magit.texi:10508
+#: sed-out/magit.texi:10509
+#, no-wrap
+msgid "Refreshing Buffers"
+msgstr "Refreshing Buffers"
 
 #. type: section
 #: sed-out/magit.texi:288 sed-out/magit.texi:303 sed-out/magit.texi:9972
@@ -961,16 +1023,12 @@ msgstr "Refreshing Buffers::"
 msgid "Conventions"
 msgstr "慣習"
 
-#. type: section
-#: sed-out/magit.texi:290 sed-out/magit.texi:9974 sed-out/magit.texi:9975
+#. type: subsection
+#: sed-out/magit.texi:293 sed-out/magit.texi:10004 sed-out/magit.texi:10006
+#: sed-out/magit.texi:10007
 #, no-wrap
-msgid "Calling Git"
-msgstr "Calling Git"
-
-#. type: menuentry
-#: sed-out/magit.texi:293 sed-out/magit.texi:10004
-msgid "Getting a Value from Git::"
-msgstr "Getting a Value from Git::"
+msgid "Getting a Value from Git"
+msgstr "Getting a Value from Git"
 
 #. type: subsection
 #: sed-out/magit.texi:293 sed-out/magit.texi:10004 sed-out/magit.texi:10098
@@ -979,21 +1037,20 @@ msgstr "Getting a Value from Git::"
 msgid "Calling Git for Effect"
 msgstr "Calling Git for Effect"
 
-#. type: section
-#: sed-out/magit.texi:296 sed-out/magit.texi:10236 sed-out/magit.texi:10237
+#. type: chapter
+#: sed-out/magit.texi:300 sed-out/magit.texi:10243 sed-out/magit.texi:10245
+#: sed-out/magit.texi:10246 sed-out/magit-section.texi:67
+#: sed-out/magit-section.texi:85 sed-out/magit-section.texi:86
 #, no-wrap
-msgid "Section Plumbing"
-msgstr "Section Plumbing"
+msgid "Creating Sections"
+msgstr "Creating Sections"
 
-#. type: menuentry
-#: sed-out/magit.texi:300 sed-out/magit.texi:10243
-msgid "Creating Sections::"
-msgstr "Creating Sections::"
-
-#. type: menuentry
-#: sed-out/magit.texi:300 sed-out/magit.texi:10243
-msgid "Section Selection::"
-msgstr "Section Selection::"
+#. type: subsection
+#: sed-out/magit.texi:300 sed-out/magit.texi:10243 sed-out/magit.texi:10322
+#: sed-out/magit.texi:10323
+#, no-wrap
+msgid "Section Selection"
+msgstr "Section Selection"
 
 #. type: subsection
 #: sed-out/magit.texi:300 sed-out/magit.texi:10243 sed-out/magit.texi:10363
@@ -1009,16 +1066,12 @@ msgstr "Matching Sections"
 msgid "Theming Faces"
 msgstr "Theming Faces"
 
-#. type: appendix
-#: sed-out/magit.texi:308 sed-out/magit.texi:10719 sed-out/magit.texi:10720
+#. type: appendixsec
+#: sed-out/magit.texi:311 sed-out/magit.texi:313 sed-out/magit.texi:10732
+#: sed-out/magit.texi:10734 sed-out/magit.texi:10735
 #, no-wrap
-msgid "FAQ"
-msgstr "FAQ"
-
-#. type: menuentry
-#: sed-out/magit.texi:311 sed-out/magit.texi:10732
-msgid "FAQ - How to @dots{}?::"
-msgstr "FAQ - How to @dots{}?::"
+msgid "FAQ - How to @dots{}?"
+msgstr "FAQ - How to @dots{}?"
 
 #. type: appendixsec
 #: sed-out/magit.texi:311 sed-out/magit.texi:323 sed-out/magit.texi:10732
@@ -1027,36 +1080,40 @@ msgstr "FAQ - How to @dots{}?::"
 msgid "FAQ - Issues and Errors"
 msgstr "FAQ - Issues and Errors"
 
-#. type: appendixsec
-#: sed-out/magit.texi:313 sed-out/magit.texi:10734 sed-out/magit.texi:10735
+#. type: appendixsubsec
+#: sed-out/magit.texi:320 sed-out/magit.texi:10744 sed-out/magit.texi:10746
+#: sed-out/magit.texi:10747
 #, no-wrap
-msgid "FAQ - How to @dots{}?"
-msgstr "FAQ - How to @dots{}?"
+msgid "How to pronounce Magit?"
+msgstr "Magitの発音は？"
 
-#. type: menuentry
-#: sed-out/magit.texi:320 sed-out/magit.texi:10744
-msgid "How to pronounce Magit?::"
-msgstr "Magitの発音は？::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:320 sed-out/magit.texi:10744 sed-out/magit.texi:10765
+#: sed-out/magit.texi:10766
+#, no-wrap
+msgid "How to show git's output?"
+msgstr "How to show git's output?"
 
-#. type: menuentry
-#: sed-out/magit.texi:320 sed-out/magit.texi:10744
-msgid "How to show git's output?::"
-msgstr "How to show git's output?::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:320 sed-out/magit.texi:10744 sed-out/magit.texi:10779
+#: sed-out/magit.texi:10780
+#, no-wrap
+msgid "How to install the gitman info manual?"
+msgstr "How to install the gitman info manual?"
 
-#. type: menuentry
-#: sed-out/magit.texi:320 sed-out/magit.texi:10744
-msgid "How to install the gitman info manual?::"
-msgstr "How to install the gitman info manual?::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:320 sed-out/magit.texi:10744 sed-out/magit.texi:10799
+#: sed-out/magit.texi:10800
+#, no-wrap
+msgid "How to show diffs for gpg-encrypted files?"
+msgstr "How to show diffs for gpg-encrypted files?"
 
-#. type: menuentry
-#: sed-out/magit.texi:320 sed-out/magit.texi:10744
-msgid "How to show diffs for gpg-encrypted files?::"
-msgstr "How to show diffs for gpg-encrypted files?::"
-
-#. type: menuentry
-#: sed-out/magit.texi:320 sed-out/magit.texi:10744
-msgid "How does branching and pushing work?::"
-msgstr "How does branching and pushing work?::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:320 sed-out/magit.texi:10744 sed-out/magit.texi:10811
+#: sed-out/magit.texi:10812
+#, no-wrap
+msgid "How does branching and pushing work?"
+msgstr "How does branching and pushing work?"
 
 #. type: appendixsubsec
 #: sed-out/magit.texi:320 sed-out/magit.texi:10744 sed-out/magit.texi:10816
@@ -1065,78 +1122,100 @@ msgstr "How does branching and pushing work?::"
 msgid "Should I disable VC@?"
 msgstr "VCを無効にする必要がありますか？"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "Magit is slow::"
-msgstr "Magit is slow::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10850
+#: sed-out/magit.texi:10851
+#, no-wrap
+msgid "Magit is slow"
+msgstr "Magit is slow"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "I changed several thousand files at once and now Magit is unusable::"
-msgstr "I changed several thousand files at once and now Magit is unusable::"
+# msgstr "一度に数千のファイルを変更したらMagitが使用できなくなりました"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10855
+#: sed-out/magit.texi:10856
+#, no-wrap
+msgid "I changed several thousand files at once and now Magit is unusable"
+msgstr "I changed several thousand files at once and now Magit is unusable"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "I am having problems committing::"
-msgstr "コミットに問題があります::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10866
+#: sed-out/magit.texi:10867
+#, no-wrap
+msgid "I am having problems committing"
+msgstr "コミットに問題があります"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "I am using MS Windows and cannot push with Magit::"
-msgstr "MS WindowsではMagitでpushできません::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10873
+#: sed-out/magit.texi:10874
+#, no-wrap
+msgid "I am using MS Windows and cannot push with Magit"
+msgstr "MS WindowsではMagitでpushできません"
 
 #. type: menuentry
 #: sed-out/magit.texi:338 sed-out/magit.texi:10848
 msgid ""
 "I am using macOS and SOMETHING works in shell, but not in Magit: I am using "
 "macOS and SOMETHING works in shell but not in Magit"
-msgstr "私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きません"
-
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "Expanding a file to show the diff causes it to disappear::"
-msgstr "ファイルを展開してdiffを表示するとファイルが消えます::"
-
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "Point is wrong in the @code{COMMIT_EDITMSG} buffer::"
-msgstr "@code{COMMIT_EDITMSG}バッファのpointが間違っています::"
-
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "The mode-line information isn't always up-to-date::"
-msgstr "モード行の情報が常に最新ではない::"
-
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "A branch and tag sharing the same name breaks SOMETHING::"
-msgstr "同じ名前を共有するブランチとタグは何かを壊します::"
-
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "My Git hooks work on the command-line but not inside Magit::"
 msgstr ""
-"私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません::"
+"私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは動きま"
+"せん: 私は macOS を使用しています。その何かはシェルでは動きますが、Magitでは"
+"動きません"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid ""
-"@code{git-commit-mode} isn't used when committing from the command-line::"
-msgstr ""
-"コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10895
+#: sed-out/magit.texi:10896
+#, no-wrap
+msgid "Expanding a file to show the diff causes it to disappear"
+msgstr "ファイルを展開してdiffを表示するとファイルが消えます"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid ""
-"Point ends up inside invisible text when jumping to a file-visiting buffer::"
-msgstr ""
-"file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にありま"
-"す::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10903
+#: sed-out/magit.texi:10904
+#, no-wrap
+msgid "Point is wrong in the @code{COMMIT_EDITMSG} buffer"
+msgstr "@code{COMMIT_EDITMSG}バッファのpointが間違っています"
 
-#. type: menuentry
-#: sed-out/magit.texi:338 sed-out/magit.texi:10848
-msgid "I am unable to stage when using Tramp from MS Windows::"
-msgstr "MS-WindowsからEmacsのTrampモードを使用するとステージできません::"
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10926
+#: sed-out/magit.texi:10927
+#, no-wrap
+msgid "The mode-line information isn't always up-to-date"
+msgstr "モード行の情報が常に最新ではない"
+
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10950
+#: sed-out/magit.texi:10951
+#, no-wrap
+msgid "A branch and tag sharing the same name breaks SOMETHING"
+msgstr "同じ名前を共有するブランチとタグは何かを壊します"
+
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10963
+#: sed-out/magit.texi:10964
+#, no-wrap
+msgid "My Git hooks work on the command-line but not inside Magit"
+msgstr "私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません"
+
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:10974
+#: sed-out/magit.texi:10975
+#, no-wrap
+msgid "@code{git-commit-mode} isn't used when committing from the command-line"
+msgstr "コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません"
+
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:11036
+#: sed-out/magit.texi:11037
+#, no-wrap
+msgid "Point ends up inside invisible text when jumping to a file-visiting buffer"
+msgstr "file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります"
+
+#. type: appendixsubsec
+#: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:11046
+#: sed-out/magit.texi:11047
+#, no-wrap
+msgid "I am unable to stage when using Tramp from MS Windows"
+msgstr "MS-WindowsからEmacsのTrampモードを使用するとステージできません"
 
 #. type: appendixsubsec
 #: sed-out/magit.texi:338 sed-out/magit.texi:10848 sed-out/magit.texi:11060
@@ -1144,12 +1223,6 @@ msgstr "MS-WindowsからEmacsのTrampモードを使用するとステージで�
 #, no-wrap
 msgid "I am no longer able to save popup defaults"
 msgstr "私はポップアップのデフォルトを保存できなくなりました"
-
-#. type: chapter
-#: sed-out/magit.texi:343 sed-out/magit.texi:344
-#, no-wrap
-msgid "Introduction"
-msgstr "Introduction"
 
 #. type: Plain text
 #: sed-out/magit.texi:360
@@ -1326,12 +1399,6 @@ msgstr ""
 "Magitは、Emacsのパッケージマネージャーを使用してインストールすることも、開発"
 "リポジトリから手動でインストールすることもできます。"
 
-#. type: section
-#: sed-out/magit.texi:434 sed-out/magit.texi:435
-#, no-wrap
-msgid "Installing from Melpa"
-msgstr "Installing from Melpa"
-
 #. type: Plain text
 #: sed-out/magit.texi:442
 msgid ""
@@ -1414,12 +1481,6 @@ msgid "Now see @ref{Post-Installation Tasks}."
 msgstr ""
 "なお、インストール後にしなければならない作業があります。こちらを参照して下さ"
 "い(@ref{Post-Installation Tasks})。"
-
-#. type: section
-#: sed-out/magit.texi:481 sed-out/magit.texi:482
-#, no-wrap
-msgid "Installing from the Git Repository"
-msgstr "Installing from the Git Repository"
 
 #. type: Plain text
 #: sed-out/magit.texi:488
@@ -1682,12 +1743,6 @@ msgstr ""
 "検討してください。@uref{https://magit.vc/donations}を参照してください。さまざ"
 "まな寄付オプションがあります。"
 
-#. type: chapter
-#: sed-out/magit.texi:598 sed-out/magit.texi:599
-#, no-wrap
-msgid "Getting Started"
-msgstr "Getting Started"
-
 #. type: Plain text
 #: sed-out/magit.texi:604
 msgid ""
@@ -1922,7 +1977,9 @@ msgstr ""
 msgid ""
 "Magit also provides a context menu and other mouse commands, see @ref{Mouse "
 "Support}."
-msgstr "Magit は、コンテキストメニューやその他マウスコマンドも提供します。 @ref{Mouse Support} を参照してください。"
+msgstr ""
+"Magit は、コンテキストメニューやその他マウスコマンドも提供します。 "
+"@ref{Mouse Support} を参照してください。"
 
 #. type: Plain text
 #: sed-out/magit.texi:697
@@ -2019,12 +2076,6 @@ msgstr ""
 "けです。したがって、バッファがロック解除されていて、そのモードとリポジトリ用"
 "に別のロック解除されたバッファがすでに存在する場合、前者のバッファは代わりに"
 "削除され、後者がその場所に表示されます。"
-
-#. type: subsection
-#: sed-out/magit.texi:755 sed-out/magit.texi:756
-#, no-wrap
-msgid "Switching Buffers"
-msgstr "バッファの切り替え"
 
 #. type: defun
 #: sed-out/magit.texi:758
@@ -2287,12 +2338,6 @@ msgstr ""
 "は、後で@code{magit-mode-quit-window}によって使用され、最後のMagitバッファが"
 "隠された(bury)ときにウィンドウを削除する必要があるかどうかを判断します。"
 
-#. type: subsection
-#: sed-out/magit.texi:860 sed-out/magit.texi:861
-#, no-wrap
-msgid "Naming Buffers"
-msgstr "バッファの名付け"
-
 #. type: defopt
 #: sed-out/magit.texi:863
 #, no-wrap
@@ -2500,12 +2545,6 @@ msgstr ""
 "これは、@code{uniquify}パッケージを使用して行われます。そのオプションをカスタ"
 "マイズして、バッファ名の一意化(uniquify)方法を制御します。"
 
-#. type: subsection
-#: sed-out/magit.texi:951 sed-out/magit.texi:952
-#, no-wrap
-msgid "Quitting Windows"
-msgstr "Quitting Windows"
-
 #. type: item
 #: sed-out/magit.texi:955
 #, no-wrap
@@ -2611,12 +2650,6 @@ msgstr ""
 "それから、ウィンドウが元々Magitバッファを表示するために作成され、隠されていた"
 "(buried)バッファがウィンドウに表示された最後の残りのMagitバッファであった場"
 "合、それは削除されます。"
-
-#. type: subsection
-#: sed-out/magit.texi:995 sed-out/magit.texi:996
-#, no-wrap
-msgid "Automatic Refreshing of Magit Buffers"
-msgstr "Automatic Refreshing of Magit Buffers"
 
 #. type: Plain text
 #: sed-out/magit.texi:1003
@@ -2813,12 +2846,6 @@ msgstr ""
 "ることに注意してください。これは、大規模なリポジトリでは遅くなる可能性があり"
 "ます。あなたがMagitのパフォーマンスに満足できない場合、明らかにこの関数をその"
 "フックに追加すべきではありません。"
-
-#. type: subsection
-#: sed-out/magit.texi:1066 sed-out/magit.texi:1067
-#, no-wrap
-msgid "Automatic Saving of File-Visiting Buffers"
-msgstr "Automatic Saving of File-Visiting Buffers"
 
 #. type: Plain text
 #: sed-out/magit.texi:1075
@@ -3186,9 +3213,9 @@ msgstr ""
 #. type: Plain text
 #: sed-out/magit.texi:1216
 msgid ""
-"However, if you use file-visiting buffers as a sort of ad hoc \"staging area"
-"\", then the automatic reverts could potentially cause data loss.  So far I "
-"have heard from only one user who uses such a workflow."
+"However, if you use file-visiting buffers as a sort of ad hoc \"staging "
+"area\", then the automatic reverts could potentially cause data loss.  So "
+"far I have heard from only one user who uses such a workflow."
 msgstr ""
 "ただし、あなたがfile-visitingバッファを一種その場しのぎ(ad hoc)の「ステージ領"
 "域」として使用する場合、自動revertによってデータが失われる可能性があります。 "
@@ -3268,12 +3295,6 @@ msgstr ""
 "されたすべてのセクションが操作されます。(タイプの違いのみよって動作が異なるだ"
 "けではなく)特定のセクションタイプに対してのみ意味のあるコマンドは、通常、セク"
 "ションタイプのキーマップにバインドされます。"
-
-#. type: subsection
-#: sed-out/magit.texi:1264 sed-out/magit.texi:1265
-#, no-wrap
-msgid "Section Movement"
-msgstr "Section Movement"
 
 #. type: Plain text
 #: sed-out/magit.texi:1270
@@ -3514,9 +3535,9 @@ msgid ""
 "the \"show more\" section.  If that is the case, then it doubles the number "
 "of commits that are being shown."
 msgstr ""
-"このフック関数はログバッファでのみ効果があり、そして@code{point}は\"show more"
-"\"(もっと見る)セクションにあります。その場合は、表示されているコミットの数が2"
-"倍になります。"
+"このフック関数はログバッファでのみ効果があり、そして@code{point}は\"show "
+"more\"(もっと見る)セクションにあります。その場合は、表示されているコミットの"
+"数が2倍になります。"
 
 #. type: defun
 #: sed-out/magit.texi:1342 sed-out/magit.texi:1350
@@ -3658,12 +3679,6 @@ msgstr ""
 "れ、このオプションはそれがどのくらいの長さかを制御します。最適なエクスペリエ"
 "ンスを得るには、この遅延やキーボードの繰り返し速度、およびグラフィカル環境や"
 "オペレーティングシステムの遅延を調整する必要がある場合があります。"
-
-#. type: subsection
-#: sed-out/magit.texi:1397 sed-out/magit.texi:1398
-#, no-wrap
-msgid "Section Visibility"
-msgstr "Section Visibility"
 
 #. type: Plain text
 #: sed-out/magit.texi:1402
@@ -4227,12 +4242,6 @@ msgstr ""
 "御します。そうしないとパフォーマンスに影響を与える可能性がありますが、そうし"
 "ないと少し醜いです。"
 
-#. type: subsection
-#: sed-out/magit.texi:1570 sed-out/magit.texi:1571
-#, no-wrap
-msgid "Section Hooks"
-msgstr "Section Hooks"
-
 #. type: Plain text
 #: sed-out/magit.texi:1578
 msgid ""
@@ -4344,12 +4353,6 @@ msgstr ""
 msgid "To remove a function from a section hook, use @code{remove-hook}."
 msgstr ""
 "セクションフックから関数を削除するには、@code{remove-hook}を使用します。"
-
-#. type: subsection
-#: sed-out/magit.texi:1616 sed-out/magit.texi:1617
-#, no-wrap
-msgid "Section Types and Values"
-msgstr "Section Types and Values"
 
 #. type: Plain text
 #: sed-out/magit.texi:1622
@@ -4465,12 +4468,6 @@ msgstr ""
 "セクションの見出しに子の数を追加するかどうか。これは、この情報の恩恵を受ける"
 "可能性のあるセクションにのみ影響します。"
 
-#. type: section
-#: sed-out/magit.texi:1662 sed-out/magit.texi:1663
-#, no-wrap
-msgid "Transient Commands"
-msgstr "トランジェントコマンド"
-
 # 飛行機の旅で言うトランジット(transit)は一時的に滞在する
 # トランジェント(transient)は一時そうであった、過ぎ去った<
 #
@@ -4555,12 +4552,6 @@ msgstr ""
 msgid "(global-set-key (kbd \"C-x M-g\") 'magit-dispatch)\n"
 msgstr "(global-set-key (kbd \"C-x M-g\") 'magit-dispatch)\n"
 
-#. type: section
-#: sed-out/magit.texi:1695 sed-out/magit.texi:1696
-#, no-wrap
-msgid "Transient Arguments and Buffer Variables"
-msgstr "Transient Arguments and Buffer Variables"
-
 #. type: Plain text
 #: sed-out/magit.texi:1709
 msgid ""
@@ -4574,7 +4565,17 @@ msgid ""
 "or saved permanently, see @ref{Saving Values,,,transient,}.  It is also "
 "possible to cycle through previously used sets of arguments using @code{C-M-"
 "p} and @code{C-M-n}, see @ref{Using History,,,transient,}."
-msgstr "Magitのトランジェント(一時的)プレフィックス(接頭辞)コマンドコマンドの多くのインフィックス(中置)引数は、それらのインフィックス引数で呼び出した@code{git}コマンドから帰って来ると、効果がなくなります。コミットを作成するコマンドは、この良い例です。ユーザーがインフィックス引数を変更した場合、それはそれに続くサフィックス(接尾辞)コマンドの呼び出しにのみ影響します。同じトランジェントプレフィックスコマンドが後で再度呼び出された場合、インフィックス引数は最初にデフォルト値にリセットされます。このデフォルト値は、現在のEmacsセッションに設定することも、永続的に保存することもできます(@ref{Saving Values,,,transient,})。 @code{C-M-p}と@code{C-M-n}を使用して、以前に使用した引数のセットを循環させることもできます(@ref{Using History,,,transient,})。"
+msgstr ""
+"Magitのトランジェント(一時的)プレフィックス(接頭辞)コマンドコマンドの多くのイ"
+"ンフィックス(中置)引数は、それらのインフィックス引数で呼び出した@code{git}コ"
+"マンドから帰って来ると、効果がなくなります。コミットを作成するコマンドは、こ"
+"の良い例です。ユーザーがインフィックス引数を変更した場合、それはそれに続くサ"
+"フィックス(接尾辞)コマンドの呼び出しにのみ影響します。同じトランジェントプレ"
+"フィックスコマンドが後で再度呼び出された場合、インフィックス引数は最初にデ"
+"フォルト値にリセットされます。このデフォルト値は、現在のEmacsセッションに設定"
+"することも、永続的に保存することもできます(@ref{Saving Values,,,"
+"transient,})。 @code{C-M-p}と@code{C-M-n}を使用して、以前に使用した引数のセッ"
+"トを循環させることもできます(@ref{Using History,,,transient,})。"
 
 #. type: Plain text
 #: sed-out/magit.texi:1717
@@ -4613,7 +4614,13 @@ msgid ""
 "that is active in the existing buffer is only a few @code{C-M-p} away.  "
 "Magit can be configured to behave like that, but because I expect that most "
 "users would not find that very convenient, it is not the default."
-msgstr "上記のように、トランジェントなポップアップが表示されている間に、以前に使用された引数のセットを循環させることができます。つまり、既存のバッファでアクティブになっている引数のセットは@code{C-M-p}の数個しか離れていないため、インフィックス(中置)引数を常にデフォルトにリセットできます。Magitはそのように動作するように構成できますが、ほとんどのユーザーにとってはそれほど便利ではないと思うので、デフォルトではありません。"
+msgstr ""
+"上記のように、トランジェントなポップアップが表示されている間に、以前に使用さ"
+"れた引数のセットを循環させることができます。つまり、既存のバッファでアクティ"
+"ブになっている引数のセットは@code{C-M-p}の数個しか離れていないため、イン"
+"フィックス(中置)引数を常にデフォルトにリセットできます。Magitはそのように動作"
+"するように構成できますが、ほとんどのユーザーにとってはそれほど便利ではないと"
+"思うので、デフォルトではありません。"
 
 #. type: Plain text
 #: sed-out/magit.texi:1741
@@ -4857,12 +4864,6 @@ msgstr ""
 #, no-wrap
 msgid "Completion Confirmation and the Selection"
 msgstr "Completion Confirmation(確認補完)とSelection(選択範囲)"
-
-#. type: subsection
-#: sed-out/magit.texi:1849 sed-out/magit.texi:1850
-#, no-wrap
-msgid "Action Confirmation"
-msgstr "アクションの確認"
 
 #. type: Plain text
 #: sed-out/magit.texi:1857
@@ -5233,12 +5234,6 @@ msgstr ""
 "み、@code{safe-with-wip}はこれらのシンボルをすべて個別に追加するのと同じ効果"
 "があります。"
 
-#. type: subsection
-#: sed-out/magit.texi:2043 sed-out/magit.texi:2044
-#, no-wrap
-msgid "Completion and Confirmation"
-msgstr "補完と確認"
-
 #. type: Plain text
 #: sed-out/magit.texi:2052
 msgid ""
@@ -5382,12 +5377,6 @@ msgstr ""
 "合、ユーザーは中止する機会が与えられます。DEFAULTは@code{nil}にすることもでき"
 "ます。この場合、エントリは効果がありません。"
 
-#. type: subsection
-#: sed-out/magit.texi:2110 sed-out/magit.texi:2111
-#, no-wrap
-msgid "The Selection"
-msgstr "選択範囲"
-
 #. type: Plain text
 #: sed-out/magit.texi:2120
 msgid ""
@@ -5508,12 +5497,6 @@ msgstr ""
 "リージョンを通常どおりに視覚化するかどうかを制御します。詳細については、doc-"
 "stringを参照してください。"
 
-#. type: subsection
-#: sed-out/magit.texi:2165 sed-out/magit.texi:2166
-#, no-wrap
-msgid "The hunk-internal region"
-msgstr "ハンク内部リージョン"
-
 #. type: Plain text
 #: sed-out/magit.texi:2170
 msgid ""
@@ -5560,12 +5543,6 @@ msgstr ""
 "は、他のターゲットの中でも、ハンクに作用することができます。 ハンク内部リー"
 "ジョンがアクティブな場合、そのようなコマンドは、ハンク全体ではなく、ハンク中"
 "のマークされた部分にのみ作用します。"
-
-#. type: subsection
-#: sed-out/magit.texi:2186 sed-out/magit.texi:2187
-#, no-wrap
-msgid "Support for Completion Frameworks"
-msgstr "補完フレームワークのサポート"
 
 #. type: Plain text
 #: sed-out/magit.texi:2194
@@ -5836,19 +5813,16 @@ msgstr ""
 "まれます。デフォルトでは、参照(ref)はフルネームのアルファベット順に並べ替えら"
 "れます(例: \"refs/heads/master\")。"
 
-#. type: section
-#: sed-out/magit.texi:2298 sed-out/magit.texi:2299
-#, no-wrap
-msgid "Mouse Support"
-msgstr "Mouse Support"
-
 #. type: Plain text
 #: sed-out/magit.texi:2304
 msgid ""
 "Double clicking on a section heading toggles the visibility of its body, if "
 "any.  Likewise clicking in the left fringe toggles the visibility of the "
 "appropriate section."
-msgstr "セクションの見出しをダブルクリックすると、その本文の可視性が切り替えられます (存在する場合)。 同様に、左フリンジをクリックすると、適切なセクションの表示に切り替わります。"
+msgstr ""
+"セクションの見出しをダブルクリックすると、その本文の可視性が切り替えられます "
+"(存在する場合)。 同様に、左フリンジをクリックすると、適切なセクションの表示に"
+"切り替わります。"
 
 #. type: Plain text
 #: sed-out/magit.texi:2308
@@ -5856,13 +5830,11 @@ msgid ""
 "A context menu is provided but has to be enabled explicitly.  In Emacs 28 "
 "and greater, enable the global mode @code{context-menu-mode}.  If you use an "
 "older Emacs release, set @code{magit-section-show-context-menu-for-emacs<28}."
-msgstr "コンテキスト メニューが提供されますが、明示的に有効にする必要があります。 Emacs 28 以降で、グローバル モード @code{context-menu-mode} を有効にします。 古い Emacs リリースを使用している場合は、@code{magit-section-show-context-menu-for-emacs<28} を設定します。"
-
-#. type: subsection
-#: sed-out/magit.texi:2320 sed-out/magit.texi:2321
-#, no-wrap
-msgid "Viewing Git Output"
-msgstr "Viewing Git Output"
+msgstr ""
+"コンテキスト メニューが提供されますが、明示的に有効にする必要があります。 "
+"Emacs 28 以降で、グローバル モード @code{context-menu-mode} を有効にします。 "
+"古い Emacs リリースを使用している場合は、@code{magit-section-show-context-"
+"menu-for-emacs<28} を設定します。"
 
 #. type: Plain text
 #: sed-out/magit.texi:2325
@@ -6012,7 +5984,14 @@ msgid ""
 "which is another reason we usually hide these error messages.  Whether some "
 "error message is relevant in the context of some unexpected behavior has to "
 "be judged on a case by case basis."
-msgstr "これは、デバッグのみを目的としています。 これを永続的に有効にしないでください。パフォーマンスに悪影響を及ぼす可能性があります。 また、git がゼロ以外の終了ステータスで終了し、エラーメッセージを出力するからといって、それがこと Magit に関してはエラーであるとは限らないことに注意してください。これが、通常、これらのエラーメッセージを非表示にするもう 1 つの理由です。 エラーメッセージが予期しない動作に関連しているかどうかは、ケースバイケースで判断する必要があります。"
+msgstr ""
+"これは、デバッグのみを目的としています。 これを永続的に有効にしないでくださ"
+"い。パフォーマンスに悪影響を及ぼす可能性があります。 また、git がゼロ以外の終"
+"了ステータスで終了し、エラーメッセージを出力するからといって、それがこと "
+"Magit に関してはエラーであるとは限らないことに注意してください。これが、通"
+"常、これらのエラーメッセージを非表示にするもう 1 つの理由です。 エラーメッ"
+"セージが予期しない動作に関連しているかどうかは、ケースバイケースで判断する必"
+"要があります。"
 
 #. type: defvar
 #: sed-out/magit.texi:2380
@@ -6046,12 +6025,6 @@ msgstr ""
 "に使用することのみを目的としています。通常magit-processバッファに送られる出力"
 "は、引き続きそこに送られます。なお、すべての出力がこれら2つのバッファのいずれ"
 "かに送られるわけではありません。"
-
-#. type: subsection
-#: sed-out/magit.texi:2392 sed-out/magit.texi:2393
-#, no-wrap
-msgid "Git Process Status"
-msgstr "Git Process Status"
 
 #. type: Plain text
 #: sed-out/magit.texi:2397
@@ -6100,12 +6073,6 @@ msgstr ""
 msgid ""
 "Process errors are additionally indicated at the top of the status buffer."
 msgstr "プロセスエラーは、ステータスバッファの先頭に追加で示されます。"
-
-#. type: subsection
-#: sed-out/magit.texi:2413 sed-out/magit.texi:2414
-#, no-wrap
-msgid "Running Git Manually"
-msgstr "Gitを手動で実行"
 
 #. type: Plain text
 #: sed-out/magit.texi:2421
@@ -6391,20 +6358,17 @@ msgstr "magit-git-mergetool"
 #. type: table
 #: sed-out/magit.texi:2496
 msgid "This command runs @samp{git mergetool --gui} in the current repository."
-msgstr "このコマンドは、現在のリポジトリで @samp{git mergetool --gui} を実行します。"
+msgstr ""
+"このコマンドは、現在のリポジトリで @samp{git mergetool --gui} を実行します。"
 
 #. type: table
 #: sed-out/magit.texi:2499 sed-out/magit.texi:4413
 msgid ""
 "With a prefix argument this acts as a transient prefix command, allowing the "
 "user to select the mergetool and change some settings."
-msgstr "前置引数を使用すると、これは一時的な前置コマンドとして機能し、ユーザーが mergetool を選択して一部の設定を変更できるようにします。"
-
-#. type: subsection
-#: sed-out/magit.texi:2501 sed-out/magit.texi:2502
-#, no-wrap
-msgid "Git Executable"
-msgstr "Git実行ファイル"
+msgstr ""
+"前置引数を使用すると、これは一時的な前置コマンドとして機能し、ユーザーが "
+"mergetool を選択して一部の設定を変更できるようにします。"
 
 #. type: Plain text
 #: sed-out/magit.texi:2506
@@ -6966,12 +6930,6 @@ msgstr ""
 "(define-key ido-common-completion-map\n"
 "  (kbd \\\"C-x g\\\") 'ido-enter-magit-status)\n"
 
-#. type: subsection
-#: sed-out/magit.texi:2765 sed-out/magit.texi:2766
-#, no-wrap
-msgid "Status Sections"
-msgstr "Status Sections"
-
 #. type: Plain text
 #: sed-out/magit.texi:2771
 msgid ""
@@ -7400,12 +7358,6 @@ msgstr ""
 "ここで使用できるその他のセクションインサーターについてはこちらを参照して下さ"
 "い(@ref{References Buffer})。"
 
-#. type: subsection
-#: sed-out/magit.texi:2925 sed-out/magit.texi:2926
-#, no-wrap
-msgid "Status Header Sections"
-msgstr "Status Header Sections"
-
 #. type: Plain text
 #: sed-out/magit.texi:2930 sed-out/magit.texi:3005
 msgid ""
@@ -7590,9 +7542,9 @@ msgid ""
 "the \"origin\" remote, or if that does not exist the first remote in "
 "alphabetic order."
 msgstr ""
-"現在のブランチにリモートが構成されていない場合は、フォールバックして\"origin"
-"\"リモートを表示します。存在しない場合は、アルファベット順に最初のリモートを"
-"表示します。"
+"現在のブランチにリモートが構成されていない場合は、フォールバックして"
+"\"origin\"リモートを表示します。存在しない場合は、アルファベット順に最初のリ"
+"モートを表示します。"
 
 #. type: defun
 #: sed-out/magit.texi:2996
@@ -7604,12 +7556,6 @@ msgstr "magit-insert-user-header"
 #: sed-out/magit.texi:2998
 msgid "Insert a header line about the current user."
 msgstr "現在のユーザーに関するヘッダー行を挿入します。"
-
-#. type: subsection
-#: sed-out/magit.texi:3000 sed-out/magit.texi:3001
-#, no-wrap
-msgid "Status Module Sections"
-msgstr "Status Module Sections"
 
 #. type: Plain text
 #: sed-out/magit.texi:3008
@@ -7864,12 +7810,6 @@ msgstr ""
 "ステータスバッファに関するその他のオプションについては、前節も参照してくださ"
 "い。"
 
-#. type: section
-#: sed-out/magit.texi:3102 sed-out/magit.texi:3103
-#, no-wrap
-msgid "Repository List"
-msgstr "Repository List"
-
 #. type: deffn
 #: sed-out/magit.texi:3105
 #, no-wrap
@@ -7919,7 +7859,12 @@ msgid ""
 "directory} bound to the toplevel of its working tree.  It has to return a "
 "string to be inserted or nil.  PROPS is an alist that supports the keys "
 "@code{:right-align}, @code{:pad-right} and @code{:sort}."
-msgstr "HEADERは、ヘッダーに表示される文字列です。WIDTHは、列の幅です。FORMATは、1つの引数とリポジトリID(通常はそのベース名)と作業ツリーの最上位に結び付けられたされた@code{default-directory}を使用して呼び出される関数です。挿入する文字列またはnilを返す必要があります。PROPSは、キー@code{:right-align}と@code{:pad-right}と@code{:sort}をサポートするalistです。"
+msgstr ""
+"HEADERは、ヘッダーに表示される文字列です。WIDTHは、列の幅です。FORMATは、1つ"
+"の引数とリポジトリID(通常はそのベース名)と作業ツリーの最上位に結び付けられた"
+"された@code{default-directory}を使用して呼び出される関数です。挿入する文字列"
+"またはnilを返す必要があります。PROPSは、キー@code{:right-align}と@code{:pad-"
+"right}と@code{:sort}をサポートするalistです。"
 
 #. type: defopt
 #: sed-out/magit.texi:3133 sed-out/magit.texi:8702
@@ -7930,7 +7875,13 @@ msgid ""
 "with functions that satisfy the interface.  Set @code{:sort} to @code{nil} "
 "to inhibit sorting; if unspecifed, then the column is sortable using the "
 "default sorter."
-msgstr "@code{:sort} 関数は、 @code{tabulated-list--get-sort} の docstring に記述されている奇妙なインターフェースを持っています。 あるいは @code{<} や @code{magit-repolist-version<} を使用できます。これらの関数は、インターフェイスを満たす関数に自動的に置き換えられます。 @code{:sort} を @code{nil} に設定してソートを禁止します。 指定しない場合、列はデフォルトのソーターを使用してソート可能です。"
+msgstr ""
+"@code{:sort} 関数は、 @code{tabulated-list--get-sort} の docstring に記述され"
+"ている奇妙なインターフェースを持っています。 あるいは @code{<} や "
+"@code{magit-repolist-version<} を使用できます。これらの関数は、インターフェイ"
+"スを満たす関数に自動的に置き換えられます。 @code{:sort} を @code{nil} に設定"
+"してソートを禁止します。 指定しない場合、列はデフォルトのソーターを使用して"
+"ソート可能です。"
 
 #. type: defopt
 #: sed-out/magit.texi:3138 sed-out/magit.texi:8707
@@ -7939,7 +7890,11 @@ msgid ""
 "per column and without any padding between columns, in which case you should "
 "use an appropriat HEADER, set WIDTH to 1, and set @code{:pad-right} to 9. "
 "@code{+} is substituted for numbers higher than 9."
-msgstr "あなたは列ごとに1文字だけを使用し、列間にパディングなしで数値列の範囲を表示したい場合があるかもしれません。その場合は、適切なHEADERを使用し、WIDTHを1に設定し、@code{:pad-right}を9に設定する必要があります。@code{+}は、9より大きい数値に置き換えられます。"
+msgstr ""
+"あなたは列ごとに1文字だけを使用し、列間にパディングなしで数値列の範囲を表示し"
+"たい場合があるかもしれません。その場合は、適切なHEADERを使用し、WIDTHを1に設"
+"定し、@code{:pad-right}を9に設定する必要があります。@code{+}は、9より大きい数"
+"値に置き換えられます。"
 
 #. type: Plain text
 #: sed-out/magit.texi:3142
@@ -8231,7 +8186,10 @@ msgstr "@kbd{f} (@code{magit-repolist-fetch})"
 msgid ""
 "This command fetches all marked repositories.  If no repositories are "
 "marked, then it offers to fetch all displayed repositories."
-msgstr "このコマンドは、マークされたすべてのリポジトリを取得します。 リポジトリがマークされていない場合は、表示されているすべてのリポジトリを取得するよう提案されます。"
+msgstr ""
+"このコマンドは、マークされたすべてのリポジトリを取得します。 リポジトリがマー"
+"クされていない場合は、表示されているすべてのリポジトリを取得するよう提案され"
+"ます。"
 
 #. type: item
 #: sed-out/magit.texi:3236
@@ -8258,7 +8216,11 @@ msgid ""
 "respective file in each marked repository in a new frame.  If no "
 "repositories are marked, then it offers to do this for all displayed "
 "repositories."
-msgstr "このコマンドは、相対ファイル名を (補完なしで) 読み取り、マークされた各リポジトリのそれぞれのファイルを新しいフレームで開きます。 リポジトリがマークされていない場合は、表示されているすべてのリポジトリに対してこれを行うことを提案します。"
+msgstr ""
+"このコマンドは、相対ファイル名を (補完なしで) 読み取り、マークされた各リポジ"
+"トリのそれぞれのファイルを新しいフレームで開きます。 リポジトリがマークされて"
+"いない場合は、表示されているすべてのリポジトリに対してこれを行うことを提案し"
+"ます。"
 
 #. type: Plain text
 #: sed-out/magit.texi:3252
@@ -8442,7 +8404,11 @@ msgid ""
 "upstream is a local branch, then also show its own upstream.  When "
 "@code{HEAD} is detached, then show log for that, the previously checked out "
 "branch and its upstream and push-target."
-msgstr "現在のブランチと、そのアップストリームと、プッシュターゲットのログを表示します。 アップストリームがローカルブランチの場合は、独自のアップストリームも表示します。 @code{HEAD} がデタッチされていると、そのログと、以前にチェックアウトされたブランチと、その上流およびプッシュターゲットが表示されます。"
+msgstr ""
+"現在のブランチと、そのアップストリームと、プッシュターゲットのログを表示しま"
+"す。 アップストリームがローカルブランチの場合は、独自のアップストリームも表示"
+"します。 @code{HEAD} がデタッチされていると、そのログと、以前にチェックアウト"
+"されたブランチと、その上流およびプッシュターゲットが表示されます。"
 
 #. type: item
 #: sed-out/magit.texi:3306
@@ -8556,12 +8522,6 @@ msgstr ""
 "現在のバッファが訪問しているファイルまたはblobのログを表示する2つの追加コマン"
 "ドが存在します(@ref{Commands for Buffers Visiting Files})。コマンド"
 "@code{magit-cherry}もログを表示します(@ref{Cherries})。"
-
-#. type: subsection
-#: sed-out/magit.texi:3343 sed-out/magit.texi:3344
-#, no-wrap
-msgid "Refreshing Logs"
-msgstr "Refreshing Logs"
 
 #. type: Plain text
 #: sed-out/magit.texi:3350
@@ -8694,12 +8654,6 @@ msgstr "magit-toggle-margin"
 #: sed-out/magit.texi:3385
 msgid "Show or hide the margin."
 msgstr "欄外(margin)を表示または非表示にします。"
-
-#. type: subsection
-#: sed-out/magit.texi:3387 sed-out/magit.texi:3388
-#, no-wrap
-msgid "Log Buffer"
-msgstr "Log Buffer"
 
 #. type: table
 #: sed-out/magit.texi:3399
@@ -9106,12 +9060,6 @@ msgstr ""
 "@code {magit-log-margin}の説明についてはこちらを参照して下さい(@ref{Log "
 "Margin})。"
 
-#. type: subsection
-#: sed-out/magit.texi:3518 sed-out/magit.texi:3519
-#, no-wrap
-msgid "Log Margin"
-msgstr "Log Margin"
-
 #. type: Plain text
 #: sed-out/magit.texi:3526
 msgid ""
@@ -9276,12 +9224,6 @@ msgstr "magit-toggle-margin-details"
 msgid "This command shows or hides details in the margin."
 msgstr "このコマンドは、欄外(margin)の詳細を表示または非表示にします。"
 
-#. type: subsection
-#: sed-out/magit.texi:3601 sed-out/magit.texi:3602
-#, no-wrap
-msgid "Select from Log"
-msgstr "Select from Log"
-
 #. type: Plain text
 #: sed-out/magit.texi:3610
 msgid ""
@@ -9374,12 +9316,6 @@ msgid ""
 msgstr ""
 "このオプションは、欄外(margin)が最初にMagit-Log-Selectモードのバッファに表示"
 "されるかどうか、およびそのフォーマット方法を指定します。"
-
-#. type: subsection
-#: sed-out/magit.texi:3660 sed-out/magit.texi:3661
-#, no-wrap
-msgid "Reflog"
-msgstr "Reflog"
 
 #. type: Plain text
 #: sed-out/magit.texi:3664 sed-out/magit.texi:3737 sed-out/magit.texi:3801
@@ -9882,12 +9818,6 @@ msgstr ""
 "ドが存在します。こちらを参照して下さい(@ref{Commands for Buffers Visiting "
 "Files})。"
 
-#. type: subsection
-#: sed-out/magit.texi:3893 sed-out/magit.texi:3894
-#, no-wrap
-msgid "Refreshing Diffs"
-msgstr "Refreshing Diffs"
-
 #. type: Plain text
 #: sed-out/magit.texi:3900
 msgid ""
@@ -10237,12 +10167,6 @@ msgstr "このコマンドは、現在のバッファの履歴を逆方向に移
 msgid "This command moves forward in current buffer's history."
 msgstr "このコマンドは、現在のバッファーの履歴を順方向に進めます。"
 
-#. type: subsection
-#: sed-out/magit.texi:4007 sed-out/magit.texi:4008
-#, no-wrap
-msgid "Commands Available in Diffs"
-msgstr "Commands Available in Diffs"
-
 #. type: Plain text
 #: sed-out/magit.texi:4011
 msgid "Some commands are only available if point is inside a diff."
@@ -10432,12 +10356,6 @@ msgstr "scroll-down"
 #: sed-out/magit.texi:4076
 msgid "This command scrolls text downward."
 msgstr "このコマンドは、テキストを下にスクロールします。"
-
-#. type: subsection
-#: sed-out/magit.texi:4078 sed-out/magit.texi:4079
-#, no-wrap
-msgid "Diff Options"
-msgstr "Diff Options"
 
 #. type: defopt
 #: sed-out/magit.texi:4081
@@ -10722,7 +10640,10 @@ msgid ""
 "Instead of, or in addition to, using delimiting horizontal lines, to "
 "emphasize the boundaries, you may wish to emphasize the text itself, using "
 "@code{magit-diff-highlight-hunk-region-using-face}."
-msgstr "Instead of, or in addition to, using delimiting horizontal lines, to emphasize the boundaries, you may wish to emphasize the text itself, using @code{magit-diff-highlight-hunk-region-using-face}."
+msgstr ""
+"Instead of, or in addition to, using delimiting horizontal lines, to "
+"emphasize the boundaries, you may wish to emphasize the text itself, using "
+"@code{magit-diff-highlight-hunk-region-using-face}."
 
 #. type: defopt
 #: sed-out/magit.texi:4207
@@ -10970,12 +10891,6 @@ msgstr ""
 "リビジョンバッファがログバッファから表示されない場合、ファイル制限は通常どお"
 "りに決定されます(@ref{Transient Arguments and Buffer Variables})。"
 
-#. type: section
-#: sed-out/magit.texi:4319 sed-out/magit.texi:4320
-#, no-wrap
-msgid "Ediffing"
-msgstr "Ediffing"
-
 #. type: Plain text
 #: sed-out/magit.texi:4324
 msgid ""
@@ -11093,7 +11008,10 @@ msgid ""
 "This command allows you to resolve outstanding conflicts in the file at "
 "point using Ediff.  If there is no file at point or if it doesn't have any "
 "unmerged changes, then this command prompts for a file."
-msgstr "このコマンドを使用すると、Ediff を使用して、ポイントしているファイルのファイル内の未解決の競合を解決できます。 ポイントしているファイルがない場合、またはマージされていない変更がない場合、このコマンドはファイルの入力を促します。"
+msgstr ""
+"このコマンドを使用すると、Ediff を使用して、ポイントしているファイルのファイ"
+"ル内の未解決の競合を解決できます。 ポイントしているファイルがない場合、または"
+"マージされていない変更がない場合、このコマンドはファイルの入力を促します。"
 
 #. type: table
 #: sed-out/magit.texi:4365 sed-out/magit.texi:4381
@@ -11113,7 +11031,11 @@ msgid ""
 "the worktree file.  Because you and/or Git may have already resolved some "
 "conflicts, that means that these buffers may not contain the actual versions "
 "from the respective blobs."
-msgstr "AとBと Ancestor(先祖) バッファーは、ワークツリーファイル内の競合マーカーから構築されます。 あなたや Git が既にいくつかの競合を解決している可能性があるため、これらのバッファーにはそれぞれのブロブの実際のバージョンが含まれていない可能性があります。"
+msgstr ""
+"AとBと Ancestor(先祖) バッファーは、ワークツリーファイル内の競合マーカーから"
+"構築されます。 あなたや Git が既にいくつかの競合を解決している可能性があるた"
+"め、これらのバッファーにはそれぞれのブロブの実際のバージョンが含まれていない"
+"可能性があります。"
 
 #. type: item
 #: sed-out/magit.texi:4371
@@ -11133,7 +11055,10 @@ msgid ""
 "This command allows you to resolve all conflicts in the file at point using "
 "Ediff.  If there is no file at point or if it doesn't have any unmerged "
 "changes, then this command prompts for a file."
-msgstr "このコマンドを使用すると、あなたは Ediff を使用してその時点でファイル内のすべての競合を解決できます。 ポイントしているファイルがない場合、またはマージされていない変更がない場合、このコマンドはファイルの入力を促します。"
+msgstr ""
+"このコマンドを使用すると、あなたは Ediff を使用してその時点でファイル内のすべ"
+"ての競合を解決できます。 ポイントしているファイルがない場合、またはマージされ"
+"ていない変更がない場合、このコマンドはファイルの入力を促します。"
 
 #. type: table
 #: sed-out/magit.texi:4386
@@ -11142,7 +11067,10 @@ msgid ""
 "ORIG}, so that you could later go back to that version.  Then it is "
 "reconstructed from the two sides of the conflict and the merge-base, if "
 "available."
-msgstr "まず、ワークツリー内のファイルが脇に移動され、サフィックス @samp{.ORIG} が追加されるため、後でそのバージョンに戻ることができます。 次に、競合の 2 つの側面とマージ ベース (利用可能な場合) から再構築されます。"
+msgstr ""
+"まず、ワークツリー内のファイルが脇に移動され、サフィックス @samp{.ORIG} が追"
+"加されるため、後でそのバージョンに戻ることができます。 次に、競合の 2 つの側"
+"面とマージ ベース (利用可能な場合) から再構築されます。"
 
 #. type: table
 #: sed-out/magit.texi:4392
@@ -11151,7 +11079,11 @@ msgid ""
 "not support that.  This means that all conflicts, that Git has already "
 "resolved, are restored.  On the other hand Ediff also tries to resolve "
 "conflicts, and in many cases Ediff and Git should produce similar results."
-msgstr "ワークツリーのファイルをそのまま使用できればよいのですが、Ediff はそれをサポートしていません。 これは、Git が既に解決したすべての競合が復元(restore)されることを意味します。 一方、Ediff も競合を解決しようとします。多くの場合、Ediff と Git は同様の結果を生成するはずです。"
+msgstr ""
+"ワークツリーのファイルをそのまま使用できればよいのですが、Ediff はそれをサ"
+"ポートしていません。 これは、Git が既に解決したすべての競合が復元(restore)さ"
+"れることを意味します。 一方、Ediff も競合を解決しようとします。多くの場合、"
+"Ediff と Git は同様の結果を生成するはずです。"
 
 #. type: table
 #: sed-out/magit.texi:4397
@@ -11159,7 +11091,10 @@ msgid ""
 "However if you have already resolved some conflicts manually, then those "
 "changes are discarded (though you can recover them from the backup file).  "
 "In such cases @code{magit-ediff-resolve-rest} might be more suitable."
-msgstr "ただし、一部の競合を手動で解決済みの場合、それらの変更は破棄されます (ただし、バックアップ ファイルから復元(recover)することはできます)。 そのような場合、 @code{magit-ediff-resolve-rest} の方が適切かもしれません。"
+msgstr ""
+"ただし、一部の競合を手動で解決済みの場合、それらの変更は破棄されます (ただ"
+"し、バックアップ ファイルから復元(recover)することはできます)。 そのような場"
+"合、 @code{magit-ediff-resolve-rest} の方が適切かもしれません。"
 
 #. type: table
 #: sed-out/magit.texi:4403
@@ -11169,7 +11104,11 @@ msgid ""
 "commits, allowing you to inspect a side in context and to use Magit commands "
 "in these buffers to do so.  Blame and log commands are particularly useful "
 "here."
-msgstr "このコマンドが @code{magit-ediff-resolve-rest} よりも優れている点は、Aと Bと Ancestorバッファーがそれぞれのコミットのブロブに対応しているため、コンテキスト内でその側を検査し、バッファ内でそうするための Magit コマンドを使用できることです。 Blame コマンドと log コマンドは、ここで特に役立ちます。"
+msgstr ""
+"このコマンドが @code{magit-ediff-resolve-rest} よりも優れている点は、Aと Bと "
+"Ancestorバッファーがそれぞれのコミットのブロブに対応しているため、コンテキス"
+"ト内でその側を検査し、バッファ内でそうするための Magit コマンドを使用できるこ"
+"とです。 Blame コマンドと log コマンドは、ここで特に役立ちます。"
 
 #. type: item
 #: sed-out/magit.texi:4404
@@ -11189,7 +11128,10 @@ msgid ""
 "This command does not actually use Ediff.  While it serves the same purpose "
 "as @samp{magit-ediff-resolve-rest}, it uses @samp{git mergetool --gui} to "
 "resolve conflicts."
-msgstr "このコマンドは、実際には Ediff を使用しません。 @samp{magit-ediff-resolve-rest} と同じ目的を果たしますが、@samp{git mergetool --gui} を使用して競合を解決します。"
+msgstr ""
+"このコマンドは、実際には Ediff を使用しません。 @samp{magit-ediff-resolve-"
+"rest} と同じ目的を果たしますが、@samp{git mergetool --gui} を使用して競合を解"
+"決します。"
 
 #. type: item
 #: sed-out/magit.texi:4414
@@ -11352,7 +11294,11 @@ msgid ""
 "This option controls which function @code{magit-ediff-dwim} uses to resolve "
 "conflicts.  One of @code{magit-ediff-resolve-rest}, @code{magit-ediff-"
 "resolve-all} or @code{magit-git-mergetool}; which are all discussed above."
-msgstr "このオプションは、競合を解決するために @code{magit-ediff-dwim} が使用する関数を制御します。 @code{magit-ediff-resolve-rest} または @code{magit-ediff-resolve-all} または @code{magit-git-mergetool} のいずれ一つです。 これらすべてはで説明されています。"
+msgstr ""
+"このオプションは、競合を解決するために @code{magit-ediff-dwim} が使用する関数"
+"を制御します。 @code{magit-ediff-resolve-rest} または @code{magit-ediff-"
+"resolve-all} または @code{magit-git-mergetool} のいずれ一つです。 これらすべ"
+"てはで説明されています。"
 
 #. type: defopt
 #: sed-out/magit.texi:4452
@@ -11769,9 +11715,9 @@ msgid ""
 "also change the others to keep things aligned.  The following %-sequences "
 "are supported:"
 msgstr ""
-"以下の変数は、個々のrefsの表示方法を制御します。これらの変数の1つ(特に\"%c"
-"\"の部分)を変更する場合は、他の変数も変更して、調整を維持する必要があります。"
-"以下の%シーケンスがサポートされています:"
+"以下の変数は、個々のrefsの表示方法を制御します。これらの変数の1つ(特に"
+"\"%c\"の部分)を変更する場合は、他の変数も変更して、調整を維持する必要がありま"
+"す。以下の%シーケンスがサポートされています:"
 
 #. type: itemize
 #: sed-out/magit.texi:4629
@@ -12136,12 +12082,6 @@ msgstr "magit-insert-tags"
 msgid "Insert sections showing all tags."
 msgstr "すべてのタグを表示するセクションを挿入します。"
 
-#. type: section
-#: sed-out/magit.texi:4784 sed-out/magit.texi:4785
-#, no-wrap
-msgid "Bisecting"
-msgstr "Bisecting"
-
 #. type: ifinfo
 #: sed-out/magit.texi:4790
 msgid "@ref{git-bisect,,,gitman,}."
@@ -12430,12 +12370,6 @@ msgstr ""
 "ン)を訪問するいくつかのコマンドを提供します。 実際には、そのようなコマンドの"
 "いくつかの「グループ」と、各グループ内のいくつかの「バリエーション」を提供し"
 "ます。"
-
-#. type: subsection
-#: sed-out/magit.texi:4889 sed-out/magit.texi:4890
-#, no-wrap
-msgid "General-Purpose Visit Commands"
-msgstr "General-Purpose Visit Commands"
 
 #. type: Plain text
 #: sed-out/magit.texi:4895
@@ -13281,12 +13215,6 @@ msgstr "magit-blame-goto-chunk-hook"
 msgid "This hook is run when moving between chunks."
 msgstr "このフックは、チャンク間を移動するときに実行されます。"
 
-#. type: section
-#: sed-out/magit.texi:5229 sed-out/magit.texi:5230
-#, no-wrap
-msgid "Creating Repository"
-msgstr "Creating Repository"
-
 #. type: item
 #: sed-out/magit.texi:5233
 #, no-wrap
@@ -13326,12 +13254,6 @@ msgstr ""
 "部に作成する必要があることを確認する必要があります。ディレクトリが既存のリポ"
 "ジトリのルートである場合、ユーザーはそれを再初期化する必要があることを確認す"
 "る必要があります。"
-
-#. type: section
-#: sed-out/magit.texi:5245 sed-out/magit.texi:5246
-#, no-wrap
-msgid "Cloning Repository"
-msgstr "Cloning Repository"
 
 #. type: Plain text
 #: sed-out/magit.texi:5253
@@ -13490,7 +13412,11 @@ msgid ""
 "sparse checkout, avoiding a checkout of the full working tree.  To add more "
 "directories, use the @code{magit-sparse-checkout} transient (see @ref{Sparse "
 "checkouts})."
-msgstr "このコマンドは、既存のリポジトリのクローンを作成し、スパースチェックアウト(sparse checkout;疎なチェックアウト)を初期化して、作業ツリー全部のチェックアウトを回避します。 さらにディレクトリを追加するには、@code{magit-sparse-checkout} トランジェントを使用します (@ref{Sparse checkouts} を参照)。"
+msgstr ""
+"このコマンドは、既存のリポジトリのクローンを作成し、スパースチェックアウト"
+"(sparse checkout;疎なチェックアウト)を初期化して、作業ツリー全部のチェックア"
+"ウトを回避します。 さらにディレクトリを追加するには、@code{magit-sparse-"
+"checkout} トランジェントを使用します (@ref{Sparse checkouts} を参照)。"
 
 #. type: item
 #: sed-out/magit.texi:5295
@@ -13779,7 +13705,12 @@ msgid ""
 "single static format) or an alist with elements @code{(HOSTNAME . FORMAT)} "
 "mapping hostnames to formats.  When an alist is used, the @code{nil} key "
 "represents the default format."
-msgstr "このオプションで指定された形式は、リポジトリ名をURLに変換するときに使用されます。@code{%h}はホスト名であり、@code{%n}は所有者の名前を含むリポジトリ名です。 値は、文字列(単一の静的フォーマットを表す)またはホスト名をフォーマットにマッピングする要素 @code{(HOSTNAME . FORMAT)} を持つ alist にすることができます。 alist が使用される場合、@code{nil} キーはデフォルトの形式を表します。"
+msgstr ""
+"このオプションで指定された形式は、リポジトリ名をURLに変換するときに使用されま"
+"す。@code{%h}はホスト名であり、@code{%n}は所有者の名前を含むリポジトリ名で"
+"す。 値は、文字列(単一の静的フォーマットを表す)またはホスト名をフォーマットに"
+"マッピングする要素 @code{(HOSTNAME . FORMAT)} を持つ alist にすることができま"
+"す。 alist が使用される場合、@code{nil} キーはデフォルトの形式を表します。"
 
 #. type: defopt
 #: sed-out/magit.texi:5399
@@ -14174,13 +14105,6 @@ msgstr ""
 "ルセクションがある場合でも、常にユーザーにファイルの入力を求めるプロンプトが"
 "表示されます。"
 
-# git apply : (どこかで作った) patch を当てる
-#. type: section
-#: sed-out/magit.texi:5544 sed-out/magit.texi:5545
-#, no-wrap
-msgid "Applying"
-msgstr "Applying"
-
 #. type: Plain text
 #: sed-out/magit.texi:5551
 msgid ""
@@ -14362,12 +14286,6 @@ msgstr ""
 "ディターがEmacsclientになるように手配します。ユーザーが編集セッションを終了す"
 "ると、Emacsclientが終了し、Gitはファイルのコンテンツをメッセージとして使用し"
 "てコミットを作成します。"
-
-#. type: subsection
-#: sed-out/magit.texi:5625 sed-out/magit.texi:5626
-#, no-wrap
-msgid "Initiating a Commit"
-msgstr "コミット開始"
 
 #. type: ifinfo
 #: sed-out/magit.texi:5631
@@ -14996,32 +14914,29 @@ msgstr ""
 "度呼び出すと、新しい変更のみを表示するか、コミットされるすべての変更を表示す"
 "るかが切り替わります。"
 
-#. type: menuentry
-#: sed-out/magit.texi:5861
-msgid "Using the Revision Stack::"
-msgstr "Using the Revision Stack::"
+#. type: unnumberedsubsubsec
+#: sed-out/magit.texi:5861 sed-out/magit.texi:5863 sed-out/magit.texi:5864
+#, no-wrap
+msgid "Using the Revision Stack"
+msgstr "Using the Revision Stack"
 
-#. type: menuentry
-#: sed-out/magit.texi:5861
-msgid "Commit Pseudo Headers::"
-msgstr "Commit Pseudo Headers::"
+#. type: unnumberedsubsubsec
+#: sed-out/magit.texi:5861 sed-out/magit.texi:5926 sed-out/magit.texi:5927
+#, no-wrap
+msgid "Commit Pseudo Headers"
+msgstr "Commit Pseudo Headers"
 
-#. type: menuentry
-#: sed-out/magit.texi:5861
-msgid "Commit Mode and Hooks::"
-msgstr "Commit Mode and Hooks::"
+#. type: unnumberedsubsubsec
+#: sed-out/magit.texi:5861 sed-out/magit.texi:5979 sed-out/magit.texi:5980
+#, no-wrap
+msgid "Commit Mode and Hooks"
+msgstr "Commit Mode and Hooks"
 
 #. type: unnumberedsubsubsec
 #: sed-out/magit.texi:5861 sed-out/magit.texi:6058 sed-out/magit.texi:6059
 #, no-wrap
 msgid "Commit Message Conventions"
 msgstr "Commit Message Conventions"
-
-#. type: unnumberedsubsubsec
-#: sed-out/magit.texi:5863 sed-out/magit.texi:5864
-#, no-wrap
-msgid "Using the Revision Stack"
-msgstr "Using the Revision Stack"
 
 #. type: item
 #: sed-out/magit.texi:5867
@@ -15173,12 +15088,6 @@ msgid ""
 msgstr ""
 "POINT-FORMATの展開はポイントに挿入され、EOB-FORMATの展開はバッファの最後に挿"
 "入されます(バッファがコメントで終了する場合は、その直前に挿入されます)。"
-
-#. type: unnumberedsubsubsec
-#: sed-out/magit.texi:5926 sed-out/magit.texi:5927
-#, no-wrap
-msgid "Commit Pseudo Headers"
-msgstr "Commit Pseudo Headers"
 
 #. type: Plain text
 #: sed-out/magit.texi:5931
@@ -15386,12 +15295,6 @@ msgstr "git-commit-suggested"
 #: sed-out/magit.texi:5977
 msgid "Insert a header mentioning the person who suggested the change."
 msgstr "変更を提案した人に言及するヘッダーを挿入します。"
-
-#. type: unnumberedsubsubsec
-#: sed-out/magit.texi:5979 sed-out/magit.texi:5980
-#, no-wrap
-msgid "Commit Mode and Hooks"
-msgstr "Commit Mode and Hooks"
 
 #. type: Plain text
 #: sed-out/magit.texi:5987
@@ -15711,12 +15614,6 @@ msgstr ""
 "する規則を制御します。値は、特定の規則を識別する自明のシンボルのリストです。"
 "それは@code{non-empty-second-line}と@code {overlong-summary-line}です。"
 
-#. type: subsection
-#: sed-out/magit.texi:6118 sed-out/magit.texi:6119
-#, no-wrap
-msgid "The Two Remotes"
-msgstr "The Two Remotes"
-
 # feature/[派生元バージョン番号など]/[機能名など]
 #
 #     機能追加・改修などを行う作業ブランチ
@@ -15783,8 +15680,8 @@ msgid ""
 "But luckily Git has long ago gained support for a push-remote which can be "
 "configured separately from the upstream branch, using the variables "
 "@code{branch.<name>.pushRemote} and @code{remote.pushDefault}.  So we no "
-"longer have to choose which of the two remotes should be used as \"the remote"
-"\"."
+"longer have to choose which of the two remotes should be used as \"the "
+"remote\"."
 msgstr ""
 "しかし幸運なことに、Gitは、変数@code{branch.<name>.pushRemote}と@code{remote."
 "pushDefault}を使用して、アップストリームブランチとは別に構成できるプッシュリ"
@@ -15825,12 +15722,6 @@ msgstr ""
 "チを処理する多くのトランジェントプレフィックスコマンドから利用できます。プッ"
 "シュ中にプッシュリモートまたはアップストリームを設定することもできます"
 "(@ref{Pushing})。"
-
-#. type: subsection
-#: sed-out/magit.texi:6165 sed-out/magit.texi:6166
-#, no-wrap
-msgid "Branch Commands"
-msgstr "Branch Commands"
 
 #. type: Plain text
 #: sed-out/magit.texi:6174
@@ -16704,12 +16595,6 @@ msgstr ""
 "(transient-replace-suffix 'magit-branch 'magit-checkout\n"
 "  '(\"b\" \"dwim\" magit-branch-or-checkout))\n"
 
-#. type: subsection
-#: sed-out/magit.texi:6491 sed-out/magit.texi:6492
-#, no-wrap
-msgid "Branch Git Variables"
-msgstr "Branch Git Variables"
-
 #. type: Plain text
 #: sed-out/magit.texi:6497
 msgid ""
@@ -17166,12 +17051,6 @@ msgstr ""
 "チ\"BRANCH-NAME\"を作成することによって行われます。削除されたreferenceに"
 "reflogがあった場合、それはブランチのreflogとして復元されます。"
 
-#. type: section
-#: sed-out/magit.texi:6697 sed-out/magit.texi:6698
-#, no-wrap
-msgid "Merging"
-msgstr "Merging"
-
 #. type: ifinfo
 #: sed-out/magit.texi:6703
 msgid "@ref{git-merge,,,gitman,}."
@@ -17492,12 +17371,6 @@ msgstr "magit-merge-abort"
 #: sed-out/magit.texi:6814
 msgid "This command aborts the current merge operation."
 msgstr "このコマンドは、現在のマージ操作を中止(abort)します。"
-
-#. type: section
-#: sed-out/magit.texi:6816 sed-out/magit.texi:6817
-#, no-wrap
-msgid "Resolving Conflicts"
-msgstr "Resolving Conflicts"
 
 #. type: Plain text
 #: sed-out/magit.texi:6825
@@ -18262,12 +18135,6 @@ msgid ""
 "branch."
 msgstr "このコマンドは、現在のリベース操作を中止し、元のブランチを復元します。"
 
-#. type: subsection
-#: sed-out/magit.texi:7100 sed-out/magit.texi:7101
-#, no-wrap
-msgid "Editing Rebase Sequences"
-msgstr "Editing Rebase Sequences"
-
 #. type: table
 #: sed-out/magit.texi:7109
 msgid ""
@@ -18826,15 +18693,20 @@ msgstr "以下の色が使用されます:"
 msgid ""
 "Commits that use the same foreground color as the @code{default} face have "
 "not been applied yet."
-msgstr "@code{default} フェイスと同じ前景色を使用するコミットはまだ適用されていません。"
+msgstr ""
+"@code{default} フェイスと同じ前景色を使用するコミットはまだ適用されていませ"
+"ん。"
 
 #. type: itemize
 #: sed-out/magit.texi:7294
 msgid ""
 "Yellow commits have some special relationship to the commit rebase stopped "
-"at.  This is used for the words \"join\", \"goal\", \"same\" and \"work"
-"\" (see below)."
-msgstr "黄色のコミットは、停止(stop)したコミットリベースと特別な関係があります。 これは、「join」や「goal」や「same」や「work」という言葉に使用されます (以下を参照)。"
+"at.  This is used for the words \"join\", \"goal\", \"same\" and "
+"\"work\" (see below)."
+msgstr ""
+"黄色のコミットは、停止(stop)したコミットリベースと特別な関係があります。 これ"
+"は、「join」や「goal」や「same」や「work」という言葉に使用されます (以下を参"
+"照)。"
 
 #. type: itemize
 #: sed-out/magit.texi:7297
@@ -19069,16 +18941,16 @@ msgstr ""
 #: sed-out/magit.texi:7421
 msgid ""
 "When a commit is prefixed with @code{goal}, then that indicates that it is "
-"still possible to create a new commit with the exact same tree (the \"goal"
-"\") without manually editing any files, by committing the index, or by "
+"still possible to create a new commit with the exact same tree (the "
+"\"goal\") without manually editing any files, by committing the index, or by "
 "staging all changes and then committing that.  This is the case when the "
 "original tree still exists in the index or worktree in untainted form."
 msgstr ""
 "接頭辞@code{goal}の場合、ファイルを手動で編集したり、インデックスをコミットし"
-"たり、ステージしたりすることなく、まったく同じツリー(つまり目標(the \"goal"
-"\"))で新しいコミットを作成できることを示しています。すべての変更とそれをコ"
-"ミットします。これは、元のツリーが汚染されていない形式でインデックスまたは"
-"ワークツリーにまだ存在する場合です。"
+"たり、ステージしたりすることなく、まったく同じツリー(つまり目標(the "
+"\"goal\"))で新しいコミットを作成できることを示しています。すべての変更とそれ"
+"をコミットします。これは、元のツリーが汚染されていない形式でインデックスまた"
+"はワークツリーにまだ存在する場合です。"
 
 #. type: itemize
 #: sed-out/magit.texi:7430
@@ -19639,12 +19511,6 @@ msgstr "@kbd{V a} (@code{magit-sequence-abort})"
 #, no-wrap
 msgid "V a"
 msgstr "V a"
-
-#. type: section
-#: sed-out/magit.texi:7660 sed-out/magit.texi:7661
-#, no-wrap
-msgid "Resetting"
-msgstr "Resetting"
 
 #. type: ifinfo
 #: sed-out/magit.texi:7666
@@ -20353,12 +20219,6 @@ msgstr ""
 "このオプションは、欄外が最初にスタッシュバッファに表示されるかどうか、および"
 "そのフォーマット方法を指定します。"
 
-#. type: subsection
-#: sed-out/magit.texi:7911 sed-out/magit.texi:7912
-#, no-wrap
-msgid "Remote Commands"
-msgstr "Remote Commands"
-
 #. type: Plain text
 #: sed-out/magit.texi:7918
 msgid ""
@@ -20687,8 +20547,8 @@ msgid ""
 "heads/*:refs/remotes/REMOTE/*\")."
 msgstr ""
 "陳腐化したrefspecのみが残っている場合、このコマンドは、リモートを削除するか、"
-"陳腐化したrefspecをデフォルトのrefspec (\"+refs/heads/*:refs/remotes/REMOTE/*"
-"\") に置き換えることを提案します。"
+"陳腐化したrefspecをデフォルトのrefspec (\"+refs/heads/*:refs/remotes/REMOTE/"
+"*\") に置き換えることを提案します。"
 
 #. type: table
 #: sed-out/magit.texi:8022
@@ -20786,7 +20646,10 @@ msgid ""
 "This variable specifies the url used for pushing to the remote named NAME@.  "
 "If it is not specified, then @code{remote.NAME.url} is used instead.  It can "
 "have multiple values."
-msgstr "この変数は、NAME@ という名前のリモートへのプッシュに使用される URL を指定します。 指定されていない場合は、代わりに @code{remote.NAME.url} が使用されます。 複数の値を持つことができます。"
+msgstr ""
+"この変数は、NAME@ という名前のリモートへのプッシュに使用される URL を指定しま"
+"す。 指定されていない場合は、代わりに @code{remote.NAME.url} が使用されま"
+"す。 複数の値を持つことができます。"
 
 #. type: defvar
 #: sed-out/magit.texi:8059
@@ -20821,12 +20684,6 @@ msgstr ""
 "の場合、タグはフェッチされません。値が@code{--tags}の場合、すべてのタグが"
 "フェッチされます。この変数に値がない場合、フェッチされたブランチから到達可能"
 "なタグのみがフェッチされます。"
-
-#. type: section
-#: sed-out/magit.texi:8071 sed-out/magit.texi:8072
-#, no-wrap
-msgid "Fetching"
-msgstr "Fetching"
 
 #. type: ifinfo
 #: sed-out/magit.texi:8077
@@ -21093,12 +20950,6 @@ msgstr ""
 "(define-key magit-mode-map \"f\" 'magit-pull) ; was magit-fetch\n"
 "(define-key magit-mode-map \"F\" nil)         ; was magit-pull\n"
 
-#. type: section
-#: sed-out/magit.texi:8164 sed-out/magit.texi:8165
-#, no-wrap
-msgid "Pulling"
-msgstr "Pulling"
-
 #. type: ifinfo
 #: sed-out/magit.texi:8170
 msgid "@ref{git-pull,,,gitman,}."
@@ -21202,12 +21053,6 @@ msgstr "magit-pull-branch"
 #: sed-out/magit.texi:8211
 msgid "This command pulls from a branch read in the minibuffer."
 msgstr "このコマンドは、ミニバッファで読み取られたブランチからプルします。"
-
-#. type: section
-#: sed-out/magit.texi:8213 sed-out/magit.texi:8214
-#, no-wrap
-msgid "Pushing"
-msgstr "Pushing"
 
 #. type: ifinfo
 #: sed-out/magit.texi:8219
@@ -21565,12 +21410,6 @@ msgstr ""
 "pushDefault}、@code{branch.<branch>.pushRemote}、@code{branch.<branch>."
 "remote}、@code{branch.<branch>.merge}、@code{remote.<remote>.push}"
 
-#. type: section
-#: sed-out/magit.texi:8349 sed-out/magit.texi:8350
-#, no-wrap
-msgid "Plain Patches"
-msgstr "Plain Patches"
-
 #. type: item
 #: sed-out/magit.texi:8353
 #, no-wrap
@@ -21887,12 +21726,6 @@ msgstr ""
 "このコマンドは、現在のパッチ適用シーケンスを中止(abort)します。 これにより、"
 "シーケンスの開始以降に行われたすべての変更が破棄されます。"
 
-#. type: section
-#: sed-out/magit.texi:8486 sed-out/magit.texi:8487
-#, no-wrap
-msgid "Tagging"
-msgstr "Tagging"
-
 #. type: ifinfo
 #: sed-out/magit.texi:8492
 msgid "@ref{git-tag,,,gitman,}."
@@ -22062,12 +21895,6 @@ msgid ""
 msgstr ""
 "このコマンドは、REMOTEにありローカルに欠落しているタグを削除することを提案し"
 "ます。その逆も同様にします。"
-
-#. type: section
-#: sed-out/magit.texi:8552 sed-out/magit.texi:8553
-#, no-wrap
-msgid "Notes"
-msgstr "Notes"
 
 #. type: ifinfo
 #: sed-out/magit.texi:8558
@@ -22360,12 +22187,6 @@ msgstr ""
 #: sed-out/magit.texi:8659
 msgid "the git-submodule(1) manpage."
 msgstr "the git-submodule(1) manpage."
-
-#. type: subsection
-#: sed-out/magit.texi:8666 sed-out/magit.texi:8667
-#, no-wrap
-msgid "Listing Submodules"
-msgstr "Listing Submodules"
 
 #. type: Plain text
 #: sed-out/magit.texi:8674
@@ -22679,12 +22500,6 @@ msgstr ""
 "ことをサポートしていないため、スーパーリポジトリもフェッチします。プレフィッ"
 "クス引数を使用すると、すべてのリモートをフェッチします。"
 
-#. type: section
-#: sed-out/magit.texi:8785 sed-out/magit.texi:8786
-#, no-wrap
-msgid "Subtree"
-msgstr "Subtree"
-
 #. type: ifinfo
 #: sed-out/magit.texi:8791
 msgid "@ref{git-subtree,,,gitman,}."
@@ -22933,16 +22748,6 @@ msgstr "magit-subtree-split"
 msgid "This command extracts the history of the subtree PREFIX@."
 msgstr "このコマンドは、サブツリーPREFIXの履歴を抽出します。"
 
-# https://qiita.com/yoichi22/items/8f92110f24690ca8966f
-# git worktree を使うと、一つのローカルリポジトリで作業ツリーを複数同時に持てる。
-# このコマンドは Git 2.5.0 から導入されている。
-# Git - git-worktree Documentation
-#. type: section
-#: sed-out/magit.texi:8866 sed-out/magit.texi:8867
-#, no-wrap
-msgid "Worktree"
-msgstr "Worktree"
-
 #. type: ifinfo
 #: sed-out/magit.texi:8872
 msgid "@ref{git-worktree,,,gitman,}."
@@ -23110,18 +22915,14 @@ msgstr ""
 "トのworktreeが、現在のバッファにステータスがすでに表示されているworktreeであ"
 "る場合は、代わりにDiredで表示します。"
 
-#. type: section
-#: sed-out/magit.texi:8920 sed-out/magit.texi:8921
-#, no-wrap
-msgid "Sparse checkouts"
-msgstr "Sparse checkouts"
-
 #. type: Plain text
 #: sed-out/magit.texi:8925
 msgid ""
 "Sparse checkouts provide a way to restrict the working tree to a subset of "
 "directories.  See"
-msgstr "スパースチェックアウトは、作業ツリーをディレクトリのサブセットに制限する方法を提供します。 以下をご覧下さい"
+msgstr ""
+"スパースチェックアウトは、作業ツリーをディレクトリのサブセットに制限する方法"
+"を提供します。 以下をご覧下さい"
 
 #. type: ifinfo
 #: sed-out/magit.texi:8927
@@ -23133,7 +22934,9 @@ msgstr "@ref{git-sparse-checkout,,,gitman,}."
 msgid ""
 "the <a href=\"http://git-scm.com/docs/git-sparse-checkout\">git-sparse-"
 "checkout(1)</a> manpage."
-msgstr "the <a href=\"http://git-scm.com/docs/git-sparse-checkout\">git-sparse-checkout(1)</a> manpage."
+msgstr ""
+"the <a href=\"http://git-scm.com/docs/git-sparse-checkout\">git-sparse-"
+"checkout(1)</a> manpage."
 
 #. type: iftex
 #: sed-out/magit.texi:8935
@@ -23149,7 +22952,12 @@ msgid ""
 "introduces a backward incompatible change, Magit's sparse checkout "
 "functionality may be updated in a way that requires a more recent Git "
 "version."
-msgstr "@strong{警告}: Git はバージョン 2.25 で @code{git sparse-checkout} コマンドを導入しましたが、まだ実験的であり、変更される可能性があると公告しています。 Magit のインターフェイスも同様と見なす必要があります。 特に、Git が下位互換性のない変更を導入した場合、Magit のスパースチェックアウト機能は、より新しい Git バージョンを必要とする方法で更新される可能性があります。"
+msgstr ""
+"@strong{警告}: Git はバージョン 2.25 で @code{git sparse-checkout} コマンドを"
+"導入しましたが、まだ実験的であり、変更される可能性があると公告しています。 "
+"Magit のインターフェイスも同様と見なす必要があります。 特に、Git が下位互換性"
+"のない変更を導入した場合、Magit のスパースチェックアウト機能は、より新しい "
+"Git バージョンを必要とする方法で更新される可能性があります。"
 
 #. type: item
 #: sed-out/magit.texi:8945
@@ -23192,7 +23000,9 @@ msgstr "magit-sparse-checkout-enable"
 msgid ""
 "This command initializes a sparse checkout that includes only the files in "
 "the top-level directory."
-msgstr "このコマンドは、最上位ディレクトリ内のファイルのみを含むスパースチェックアウトを初期化します。"
+msgstr ""
+"このコマンドは、最上位ディレクトリ内のファイルのみを含むスパースチェックアウ"
+"トを初期化します。"
 
 #. type: table
 #: sed-out/magit.texi:8964
@@ -23203,7 +23013,13 @@ msgid ""
 "initialize a sparse checkout after calling @code{magit-sparse-checkout-"
 "disable}, to pass additional arguments to @code{git sparse-checkout init}, "
 "or to execute the initialization asynchronously."
-msgstr "注意: @code{magit-sparse-checkout-set} と @code{magit-sparse-checkout-add} は、必要に応じてスパースチェックアウトを自動的に初期化することに注意してください。 ただし、@code{magit-sparse-checkout-enable} を明示的に呼び出して、@code{magit-sparse-checkout-disable} を呼び出した後にスパースチェックアウトを再初期化し、追加の引数を @code{git sparse-checkout init} に渡すこともできます。 または初期化を非同期で実行します。"
+msgstr ""
+"注意: @code{magit-sparse-checkout-set} と @code{magit-sparse-checkout-add} "
+"は、必要に応じてスパースチェックアウトを自動的に初期化することに注意してくだ"
+"さい。 ただし、@code{magit-sparse-checkout-enable} を明示的に呼び出して、"
+"@code{magit-sparse-checkout-disable} を呼び出した後にスパースチェックアウトを"
+"再初期化し、追加の引数を @code{git sparse-checkout init} に渡すこともできま"
+"す。 または初期化を非同期で実行します。"
 
 #. type: item
 #: sed-out/magit.texi:8965
@@ -23229,7 +23045,11 @@ msgid ""
 "This command takes a list of directories and configures the sparse checkout "
 "to include only files in those subdirectories.  Any previously included "
 "directories are excluded unless they are in the provided list of directories."
-msgstr "このコマンドは、ディレクトリのリストを取得し、それらのサブディレクトリ内のファイルのみを含めるようにスパースチェックアウトを構成します。 指定されたディレクトリのリストに含まれていない限り、以前に含まれていたディレクトリは除外されます。"
+msgstr ""
+"このコマンドは、ディレクトリのリストを取得し、それらのサブディレクトリ内の"
+"ファイルのみを含めるようにスパースチェックアウトを構成します。 指定されたディ"
+"レクトリのリストに含まれていない限り、以前に含まれていたディレクトリは除外さ"
+"れます。"
 
 #. type: item
 #: sed-out/magit.texi:8973
@@ -23255,7 +23075,10 @@ msgid ""
 "This command is like @code{magit-sparse-checkout-set}, but instead adds the "
 "specified list of directories to the set of directories that is already "
 "included in the sparse checkout."
-msgstr "このコマンドは @code{magit-sparse-checkout-set} に似ていますが、代わりに、指定されたディレクトリのリストを、スパース チェックアウトに既に含まれているディレクトリのセットに追加します。"
+msgstr ""
+"このコマンドは @code{magit-sparse-checkout-set} に似ていますが、代わりに、指"
+"定されたディレクトリのリストを、スパース チェックアウトに既に含まれているディ"
+"レクトリのセットに追加します。"
 
 #. type: item
 #: sed-out/magit.texi:8980
@@ -23281,7 +23104,10 @@ msgid ""
 "This command applies the currently configured sparse checkout patterns to "
 "the working tree.  This is useful to call if excluded files have been "
 "checked out after operations such as merging or rebasing."
-msgstr "このコマンドは、現在構成されているスパースチェックアウトパターンを作業ツリーに適用します。 これは、マージやリベースなどの操作の後に除外されたファイルがチェックアウトされている場合に呼び出すと便利です。"
+msgstr ""
+"このコマンドは、現在構成されているスパースチェックアウトパターンを作業ツリー"
+"に適用します。 これは、マージやリベースなどの操作の後に除外されたファイルが"
+"チェックアウトされている場合に呼び出すと便利です。"
 
 #. type: item
 #: sed-out/magit.texi:8988
@@ -23306,7 +23132,10 @@ msgstr "magit-sparse-checkout-disable"
 msgid ""
 "This command restores the full checkout.  To return to the previous sparse "
 "checkout, call @code{magit-sparse-checkout-enable}."
-msgstr "このコマンドは、完全なチェックアウト(full checkout)を復元(restore)します。 以前のスパースチェックアウトに戻るには、 @code{magit-sparse-checkout-enable} を呼び出します。"
+msgstr ""
+"このコマンドは、完全なチェックアウト(full checkout)を復元(restore)します。 以"
+"前のスパースチェックアウトに戻るには、 @code{magit-sparse-checkout-enable} を"
+"呼び出します。"
 
 #. type: Plain text
 #: sed-out/magit.texi:8998
@@ -23314,7 +23143,10 @@ msgid ""
 "A sparse checkout can also be initiated when cloning a repository by using "
 "the @code{magit-clone-sparse} command in the @code{magit-clone} transient "
 "(see @ref{Cloning Repository})."
-msgstr "@code{magit-clone} トランジェントで @code{magit-clone-sparse} コマンドを使用してリポジトリのクローンを作成するときに、スパースチェックアウトを開始することもできます (@ref{Cloning Repository} を参照)。"
+msgstr ""
+"@code{magit-clone} トランジェントで @code{magit-clone-sparse} コマンドを使用"
+"してリポジトリのクローンを作成するときに、スパースチェックアウトを開始するこ"
+"ともできます (@ref{Cloning Repository} を参照)。"
 
 #. type: Plain text
 #: sed-out/magit.texi:9002
@@ -23322,13 +23154,10 @@ msgid ""
 "If you want the status buffer to indicate when a sparse checkout is enabled, "
 "add the function @code{magit-sparse-checkout-insert-header} to @code{magit-"
 "status-headers-hook}."
-msgstr "スパースチェックアウトが有効になっていることをステータスバッファーに表示する場合は、関数 @code{magit-sparse-checkout-insert-header} を @code{magit-status-headers-hook} に追加します。"
-
-#. type: section
-#: sed-out/magit.texi:9003 sed-out/magit.texi:9004
-#, no-wrap
-msgid "Bundle"
-msgstr "Bundle"
+msgstr ""
+"スパースチェックアウトが有効になっていることをステータスバッファーに表示する"
+"場合は、関数 @code{magit-sparse-checkout-insert-header} を @code{magit-"
+"status-headers-hook} に追加します。"
 
 # git-book
 # 7.12 Git のさまざまなツール - バンドルファイルの作成
@@ -23366,12 +23195,6 @@ msgstr ""
 "サブコマンドを実行するためのいくつかのサフィックス(接尾辞)コマンドを結び付"
 "け、サフィックスコマンドが呼び出されるまでそれらを一時バッファ(temporary "
 "buffer)に表示します。"
-
-#. type: section
-#: sed-out/magit.texi:9025 sed-out/magit.texi:9026
-#, no-wrap
-msgid "Common Commands"
-msgstr "Common Commands"
 
 #. type: deffn
 #: sed-out/magit.texi:9028
@@ -23793,12 +23616,6 @@ msgstr "magit-wip-mode-lighter"
 msgid "Mode-line lighter for @code{magit-wip--mode}."
 msgstr "@code{magit-wip--mode}のモードラインライター(lighter)。"
 
-#. type: subsection
-#: sed-out/magit.texi:9201 sed-out/magit.texi:9202
-#, no-wrap
-msgid "Wip Graph"
-msgstr "Wip Graph"
-
 #. type: defopt
 #: sed-out/magit.texi:9204
 #, no-wrap
@@ -24110,12 +23927,6 @@ msgstr "magit-wip-initial-backup-mode-lighter"
 #: sed-out/magit.texi:9330
 msgid "Mode-line lighter for @code{magit-wip-initial-backup-mode}."
 msgstr "@code{magit-wip-initial-backup-mode}のモードラインライター(lighter)"
-
-#. type: section
-#: sed-out/magit.texi:9332 sed-out/magit.texi:9333
-#, no-wrap
-msgid "Commands for Buffers Visiting Files"
-msgstr "Commands for Buffers Visiting Files"
 
 #. type: Plain text
 #: sed-out/magit.texi:9342
@@ -24569,10 +24380,10 @@ msgstr ""
 #. type: Plain text
 #: sed-out/magit.texi:9493
 msgid ""
-"To enable them invoke the transient (@code{C-c M-g}), enter \"edit mode"
-"\" (@code{C-x l}), set the \"transient level\" (@code{C-x l} again), enter "
-"@code{5}, and leave edit mode (@code{C-g}).  Also see @ref{Enabling and "
-"Disabling Suffixes,,,transient,}."
+"To enable them invoke the transient (@code{C-c M-g}), enter \"edit "
+"mode\" (@code{C-x l}), set the \"transient level\" (@code{C-x l} again), "
+"enter @code{5}, and leave edit mode (@code{C-g}).  Also see @ref{Enabling "
+"and Disabling Suffixes,,,transient,}."
 msgstr ""
 "それらを有効にするには、トランジェントコマンド(@code{C-c M-g})を呼び出し、"
 "「編集モード」(@code{C-x l})に入り、「トランジェントレベル」(再び@code{C-x "
@@ -24694,12 +24505,6 @@ msgstr ""
 #: sed-out/magit.texi:9553
 msgid "I intend to address these and similar issues in a future release."
 msgstr "今後のリリースで、これらの問題や同様の問題に対処する予定です。"
-
-#. type: section
-#: sed-out/magit.texi:9559 sed-out/magit.texi:9560
-#, no-wrap
-msgid "Per-Repository Configuration"
-msgstr "Per-Repository Configuration"
 
 #. type: Plain text
 #: sed-out/magit.texi:9564
@@ -24868,12 +24673,6 @@ msgstr ""
 "次の2つの節は、安全性やパフォーマンス上の理由から、多くのユーザーがカスタマイ"
 "ズする可能性のあるいくつかの変数について説明します。"
 
-#. type: subsection
-#: sed-out/magit.texi:9663 sed-out/magit.texi:9664
-#, no-wrap
-msgid "Safety"
-msgstr "Safety"
-
 #. type: Plain text
 #: sed-out/magit.texi:9668
 msgid ""
@@ -24948,12 +24747,6 @@ msgstr ""
 "は自動的revertされます。 これは見た目ほど危険ではありませんが、十分な情報に基"
 "づいて決定を下すには確認が必要です。こちらを参照して下さい(@ref{Risk of "
 "Reverting Automatically})"
-
-#. type: subsection
-#: sed-out/magit.texi:9695 sed-out/magit.texi:9696
-#, no-wrap
-msgid "Performance"
-msgstr "Performance"
 
 #. type: Plain text
 #: sed-out/magit.texi:9706
@@ -25098,10 +24891,11 @@ msgstr ""
 "ります。したがって、前節で説明されているように、@code{magit-insert-tags-"
 "headers}を無効にすることをお勧めします。"
 
-#. type: menuentry
-#: sed-out/magit.texi:9761
-msgid "Microsoft Windows Performance::"
-msgstr "Microsoft Windows Performance::"
+#. type: unnumberedsubsubsec
+#: sed-out/magit.texi:9761 sed-out/magit.texi:9855 sed-out/magit.texi:9856
+#, no-wrap
+msgid "Microsoft Windows Performance"
+msgstr "Microsoft Windows Performance"
 
 #. type: unnumberedsubsubsec
 #: sed-out/magit.texi:9761 sed-out/magit.texi:9883 sed-out/magit.texi:9884
@@ -25324,12 +25118,6 @@ msgstr ""
 "と、diffバッファが壊れてしまいますが、この方法で行うと、通常はdiffを確認でき"
 "るという利点があります。これは、潜在的な問題を見つける可能性が高くなるため便"
 "利です。"
-
-#. type: unnumberedsubsubsec
-#: sed-out/magit.texi:9855 sed-out/magit.texi:9856
-#, no-wrap
-msgid "Microsoft Windows Performance"
-msgstr "Microsoft Windows Performance"
 
 #. type: Plain text
 #: sed-out/magit.texi:9863
@@ -25637,12 +25425,6 @@ msgstr ""
 "るか、および実行可能ファイルの終了時にリフレッシュをトリガーするかどうかに応"
 "じて、さらにサブグループに分割できます。"
 
-#. type: subsection
-#: sed-out/magit.texi:10006 sed-out/magit.texi:10007
-#, no-wrap
-msgid "Getting a Value from Git"
-msgstr "Getting a Value from Git"
-
 #. type: Plain text
 #: sed-out/magit.texi:10012
 msgid ""
@@ -25805,8 +25587,8 @@ msgstr "magit-process-git destination &rest args"
 msgid ""
 "Calls Git synchronously in a separate process, returning its exit code.  "
 "DESTINATION specifies how to handle the output, like for @code{call-"
-"process}, except that file handlers are supported.  Enables Cygwin's \"noglob"
-"\" option during the call and ensures unix eol conversion."
+"process}, except that file handlers are supported.  Enables Cygwin's "
+"\"noglob\" option during the call and ensures unix eol conversion."
 msgstr ""
 "別のプロセスでGitを同期的に呼び出し、終了コードを返します。DESTINATIONは、"
 "ファイルハンドラーがサポートされていることを除いて、@code{call-process}のよう"
@@ -26226,12 +26008,6 @@ msgstr ""
 "これがnil以外の場合、gitがゼロ以外の終了ステータスで終了すると、@code{magit-"
 "process-sentinel}はエラーを発生させます。これはデバッグ用です。"
 
-#. type: subsection
-#: sed-out/magit.texi:10245 sed-out/magit.texi:10246
-#, no-wrap
-msgid "Creating Sections"
-msgstr "Creating Sections"
-
 #. type: defmac
 #: sed-out/magit.texi:10248
 #, no-wrap
@@ -26313,37 +26089,44 @@ msgstr ""
 "されます。 BODYは、@code{point}を前進させる責任があります。"
 
 #. type: defmac
-#: sed-out/magit.texi:10282
+#: sed-out/magit.texi:10282 sed-out/magit-section.texi:130
+#, fuzzy
 msgid ""
 "If it turns out inside BODY that the section is empty, then @code{magit-"
 "cancel-section} can be used to abort and remove all traces of the partially "
 "inserted section.  This can happen when creating a section by washing Git's "
 "output and Git didn't actually output anything this time around."
 msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
+"を使用して、部分的に挿入されたセクションのすべてのトレースを中止して削除でき"
+"ます。これは、Gitの出力を洗浄(wash)してセクションを作成し、Gitが今回は実際に"
+"は何も出力しなかった場合に発生する可能性があります。\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "セクションが空であることがBODY内で判明した場合は、@code{magit-cancel-section}"
 "を使用して、部分的に挿入されたセクションのすべてのトレースを中止および削除で"
 "きます。これは、Gitの出力を洗浄してセクションを作成し、Gitが今回は実際には何"
 "も出力しなかった場合に発生する可能性があります。"
 
 #. type: defun
-#: sed-out/magit.texi:10284
+#: sed-out/magit.texi:10284 sed-out/magit-section.texi:132
 #, no-wrap
 msgid "magit-insert-heading &rest args"
 msgstr "magit-insert-heading &rest args"
 
 #. type: defun
-#: sed-out/magit.texi:10286
+#: sed-out/magit.texi:10286 sed-out/magit-section.texi:134
 msgid "Insert the heading for the section currently being inserted."
 msgstr "現在挿入されているセクションの見出しを挿入します。"
 
 #. type: defun
-#: sed-out/magit.texi:10288
+#: sed-out/magit.texi:10288 sed-out/magit-section.texi:136
 msgid "This function should only be used inside @code{magit-insert-section}."
 msgstr ""
 "この関数は、@code{magit-insert-section}内でのみ使用する必要があります。"
 
 #. type: defun
-#: sed-out/magit.texi:10293
+#: sed-out/magit.texi:10293 sed-out/magit-section.texi:141
 msgid ""
 "When called without any arguments, then just set the @code{content} slot of "
 "the object representing the section being inserted to a marker at "
@@ -26392,7 +26175,7 @@ msgstr ""
 "することです。"
 
 #. type: defun
-#: sed-out/magit.texi:10311
+#: sed-out/magit.texi:10311 sed-out/magit-section.texi:168
 #, no-wrap
 msgid "magit-cancel-section"
 msgstr "magit-cancel-section"
@@ -26424,14 +26207,8 @@ msgstr ""
 "insert-section}への最も内側の呼び出しが終了し、その呼び出し内ですでに発生した"
 "ことのすべての痕跡が削除されます。"
 
-#. type: subsection
-#: sed-out/magit.texi:10322 sed-out/magit.texi:10323
-#, no-wrap
-msgid "Section Selection"
-msgstr "Section Selection"
-
 #. type: defun
-#: sed-out/magit.texi:10325
+#: sed-out/magit.texi:10325 sed-out/magit-section.texi:182
 #, no-wrap
 msgid "magit-current-section"
 msgstr "magit-current-section"
@@ -26543,7 +26320,7 @@ msgstr ""
 "としています。"
 
 #. type: defun
-#: sed-out/magit.texi:10373
+#: sed-out/magit.texi:10373 sed-out/magit-section.texi:195
 #, no-wrap
 msgid "magit-section-ident section"
 msgstr "magit-section-ident section"
@@ -26557,7 +26334,7 @@ msgstr ""
 "SECTIONの一意のIDを返します。戻り値の形式は@code{((TYPE . VALUE)...)}です。"
 
 #. type: defun
-#: sed-out/magit.texi:10378
+#: sed-out/magit.texi:10378 sed-out/magit-section.texi:212
 #, no-wrap
 msgid "magit-get-section ident &optional root"
 msgstr "magit-get-section ident &optional root"
@@ -26589,7 +26366,7 @@ msgstr ""
 "ションがない場合は、@code{nil}を返します。"
 
 #. type: defun
-#: sed-out/magit.texi:10390
+#: sed-out/magit.texi:10390 sed-out/magit-section.texi:264
 msgid "CONDITION can take the following forms:"
 msgstr "CONDITIONは、以下の形式をとることができます:"
 
@@ -26646,7 +26423,8 @@ msgstr ""
 "セクションのクラスに関係なくです。"
 
 #. type: defun
-#: sed-out/magit.texi:10425
+#: sed-out/magit.texi:10425 sed-out/magit-section.texi:290
+#, fuzzy
 msgid ""
 "Each CLASS should be a class symbol, identifying a class that derives from "
 "@code{magit-section}.  For backward compatibility CLASS can also be a \"type "
@@ -26655,6 +26433,14 @@ msgid ""
 "type-alist}, then a section also matches that type if its class is a "
 "subclass of the class that corresponds to the type as per that alist."
 msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
+"る必要があります。下位互換性のために、CLASSは\"type symbol\"にすることもでき"
+"ます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシンボ"
+"ルに一致します。タイプシンボルの@code{magit--section-type-alist}にエントリが"
+"ある場合、そのクラスがそのalistのタイプに対応するクラスのサブクラスであれば、"
+"セクションもそのタイプに一致します。\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "各CLASSは、@code{magit-section}から派生したクラスを識別するクラスシンボルであ"
 "る必要があります。下位互換性のために、CLASSは「タイプシンボル」にすることもで"
 "きます。@code{type}スロットの値が@code{eq}の場合、セクションはそのようなシン"
@@ -26663,29 +26449,35 @@ msgstr ""
 "ば、セクションもそのタイプに一致します。"
 
 #. type: defun
-#: sed-out/magit.texi:10429
+#: sed-out/magit.texi:10429 sed-out/magit-section.texi:294
+#, fuzzy
 msgid ""
 "Note that it is not necessary to specify the complete section lineage as "
 "printed by @code{magit-describe-section-briefly}, unless of course you want "
 "to be that precise."
 msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"注意: もちろん、正確にしたい場合を除いて、@code{magit-describe-section-"
+"briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
+"してください。\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "注意: もちろん正確にしたい場合を除いて、あなたは@code{magit-describe-section-"
 "briefly}によって出力される完全なセクション系統を指定する必要はないことに注意"
 "してください。"
 
 #. type: defun
-#: sed-out/magit.texi:10431
+#: sed-out/magit.texi:10431 sed-out/magit-section.texi:296
 #, no-wrap
 msgid "magit-section-value-if condition &optional section"
 msgstr "magit-section-value-if condition &optional section"
 
 #. type: defun
-#: sed-out/magit.texi:10433
+#: sed-out/magit.texi:10433 sed-out/magit-section.texi:298
 msgid "If the section at point matches CONDITION, then return its value."
 msgstr "ポイントのセクションがCONDITIONと一致する場合は、その値を返します。"
 
 #. type: defun
-#: sed-out/magit.texi:10438
+#: sed-out/magit.texi:10438 sed-out/magit-section.texi:303
 msgid ""
 "If optional SECTION is non-nil then test whether that matches instead.  If "
 "there is no section at point and SECTION is nil, then return nil.  If the "
@@ -26696,20 +26488,24 @@ msgstr ""
 "クションが一致しない場合は、nilを返します。"
 
 #. type: defun
-#: sed-out/magit.texi:10440
+#: sed-out/magit.texi:10440 sed-out/magit-section.texi:305
+#, fuzzy
 msgid "See @code{magit-section-match} for the forms CONDITION can take."
 msgstr ""
+"#-#-#-#-#  magit-section.ja.po (magit-docs-ja 0.0)  #-#-#-#-#\n"
+"CONDITIONが取ることができる形式については→@code{magit-section-match}\n"
+"#-#-#-#-#  magit.ja.po (magit-docs-ja 0.1)  #-#-#-#-#\n"
 "CONDITIONが取ることができる形式については、@code{magit-section-match}を参照し"
 "てください。"
 
-#. type: defun
-#: sed-out/magit.texi:10442
+#. type: defmac
+#: sed-out/magit.texi:10442 sed-out/magit-section.texi:307
 #, no-wrap
 msgid "magit-section-case &rest clauses"
 msgstr "magit-section-case &rest clauses"
 
-#. type: defun
-#: sed-out/magit.texi:10444
+#. type: defmac
+#: sed-out/magit.texi:10444 sed-out/magit-section.texi:309
 msgid "Choose among clauses on the type of the section at point."
 msgstr "ポイントのセクションのタイプに関する条項(clauses)から選択します。"
 
@@ -26871,12 +26667,6 @@ msgstr ""
 "オプションのSTRICTがnil以外の場合、ポイントのセクションのdiffタイプが"
 "@code{untracked}であるか、ポイントのセクションが実際には@code{diff}ではなく"
 "@code{diffstat}セクションである場合は、nilを返します。"
-
-#. type: section
-#: sed-out/magit.texi:10508 sed-out/magit.texi:10509
-#, no-wrap
-msgid "Refreshing Buffers"
-msgstr "Refreshing Buffers"
 
 #. type: Plain text
 #: sed-out/magit.texi:10516
@@ -27179,12 +26969,13 @@ msgstr ""
 #: sed-out/magit.texi:10652
 msgid ""
 "Magit highlights the current section.  If a section has subsections, then "
-"all of them are highlighted.  This is done using faces that have \"highlight"
-"\" in their names.  For most sections, @code{magit-section-highlight} is "
-"used for both the body and the heading.  Like the @code{region} face, it "
-"should only set the background color to something similar to that of "
-"@code{default}.  The highlight background color must be different from both "
-"the @code{region} background color and the @code{default} background color."
+"all of them are highlighted.  This is done using faces that have "
+"\"highlight\" in their names.  For most sections, @code{magit-section-"
+"highlight} is used for both the body and the heading.  Like the "
+"@code{region} face, it should only set the background color to something "
+"similar to that of @code{default}.  The highlight background color must be "
+"different from both the @code{region} background color and the "
+"@code{default} background color."
 msgstr ""
 "Magitは現在のセクションを強調表示します。セクションにサブセクションがある場"
 "合、それらすべてが強調表示されます。これは、名前に\"highlight\"が含まれている"
@@ -27350,12 +27141,6 @@ msgstr ""
 msgid "Please also see @ref{Debugging Tools}."
 msgstr "どうぞこちらご覧下さい @ref{Debugging Tools}"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10746 sed-out/magit.texi:10747
-#, no-wrap
-msgid "How to pronounce Magit?"
-msgstr "Magitの発音は？"
-
 #. type: Plain text
 #: sed-out/magit.texi:10750
 msgid "Either @code{mu[m's] git} or @code{magi@{c => t@}} is fine."
@@ -27402,12 +27187,6 @@ msgstr ""
 "が存在しない模様)。 こちらもご覧ください@uref{https://emacs.stackexchange."
 "com/questions/13696}"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10765 sed-out/magit.texi:10766
-#, no-wrap
-msgid "How to show git's output?"
-msgstr "How to show git's output?"
-
 #. type: Plain text
 #: sed-out/magit.texi:10772
 msgid ""
@@ -27435,12 +27214,6 @@ msgstr ""
 "バッファに挿入することもコストがかかりすぎます。デバッグの目的で、"
 "@code{magit-git-debug}を@code{t}に設定することで、とにかくそうすることができ"
 "ます。"
-
-#. type: appendixsubsec
-#: sed-out/magit.texi:10779 sed-out/magit.texi:10780
-#, no-wrap
-msgid "How to install the gitman info manual?"
-msgstr "How to install the gitman info manual?"
 
 #. type: Plain text
 #: sed-out/magit.texi:10785
@@ -27483,12 +27256,6 @@ msgstr ""
 msgid "(setq magit-view-git-manual-method 'man)\n"
 msgstr "(setq magit-view-git-manual-method 'man)\n"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10799 sed-out/magit.texi:10800
-#, no-wrap
-msgid "How to show diffs for gpg-encrypted files?"
-msgstr "How to show diffs for gpg-encrypted files?"
-
 #. type: Plain text
 #: sed-out/magit.texi:10805
 msgid ""
@@ -27510,17 +27277,13 @@ msgstr ""
 "git config --global diff.gpg.textconv \"gpg --no-tty --decrypt\"\n"
 "echo \"*.gpg filter=gpg diff=gpg\" > .gitattributes\n"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10811 sed-out/magit.texi:10812
-#, no-wrap
-msgid "How does branching and pushing work?"
-msgstr "How does branching and pushing work?"
-
 #. type: Plain text
 #: sed-out/magit.texi:10815
 msgid ""
 "Please see @ref{Branching} and @uref{http://emacsair.me/2016/01/17/magit-2.4}"
-msgstr "こちらをご覧ください @ref{Branching} と @uref{http://emacsair.me/2016/01/18/magit-2.4}"
+msgstr ""
+"こちらをご覧ください @ref{Branching} と @uref{http://emacsair.me/2016/01/18/"
+"magit-2.4}"
 
 #. type: Plain text
 #: sed-out/magit.texi:10822
@@ -27552,25 +27315,14 @@ msgstr ""
 "あなたがとにかくVCを無効にすることを選択した場合は、@code{vc-handled-"
 "backends}の値を変更することで無効にできます。"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10850 sed-out/magit.texi:10851
-#, no-wrap
-msgid "Magit is slow"
-msgstr "Magit is slow"
-
 #. type: Plain text
 #: sed-out/magit.texi:10854
 msgid ""
 "See @ref{Performance} and @ref{I changed several thousand files at once and "
 "now Magit is unusable}."
-msgstr "@ref{Performance} や @ref{I changed several thousand files at once and now Magit is unusable} を参照してください。"
-
-# msgstr "一度に数千のファイルを変更したらMagitが使用できなくなりました"
-#. type: appendixsubsec
-#: sed-out/magit.texi:10855 sed-out/magit.texi:10856
-#, no-wrap
-msgid "I changed several thousand files at once and now Magit is unusable"
-msgstr "I changed several thousand files at once and now Magit is unusable"
+msgstr ""
+"@ref{Performance} や @ref{I changed several thousand files at once and now "
+"Magit is unusable} を参照してください。"
 
 #. type: Plain text
 #: sed-out/magit.texi:10862
@@ -27579,7 +27331,12 @@ msgid ""
 "would be nice if it did.  Reaching satisfactory performance under such "
 "conditions will require some heavy refactoring.  This is no small task but I "
 "hope to eventually find the time to make it happen."
-msgstr "(一度に数千のファイルを変更したら、Magit が使用できなくなりました)Magit は現在、このような状況下ではうまく機能しないと予想されます。 ちゃんと動くと素敵ですよね。 このような条件下で満足のいくパフォーマンスを達成するには、かなりのリファクタリングが必要になります。 これは簡単な作業ではありませんが、最終的には時間を見つけて実現したいと考えています。"
+msgstr ""
+"(一度に数千のファイルを変更したら、Magit が使用できなくなりました)Magit は現"
+"在、このような状況下ではうまく機能しないと予想されます。 ちゃんと動くと素敵で"
+"すよね。 このような条件下で満足のいくパフォーマンスを達成するには、かなりのリ"
+"ファクタリングが必要になります。 これは簡単な作業ではありませんが、最終的には"
+"時間を見つけて実現したいと考えています。"
 
 #. type: Plain text
 #: sed-out/magit.texi:10865
@@ -27589,12 +27346,6 @@ msgid ""
 msgstr ""
 "ただし、今のところは、コマンドラインを使用してこのコミットを完了することをお"
 "勧めします。こちらも参照して下さい(@ref{Performance})。"
-
-#. type: appendixsubsec
-#: sed-out/magit.texi:10866 sed-out/magit.texi:10867
-#, no-wrap
-msgid "I am having problems committing"
-msgstr "コミットに問題があります"
 
 #. type: Plain text
 #: sed-out/magit.texi:10872
@@ -27606,12 +27357,6 @@ msgstr ""
 "これは、Magitが適切なemacsclient実行可能ファイルを見つけるのに問題があること"
 "を意味している可能性があります(@ref{Configuring With-Editor,,,with-editor,} "
 "and @ref{Debugging,,,with-editor,})。"
-
-#. type: appendixsubsec
-#: sed-out/magit.texi:10873 sed-out/magit.texi:10874
-#, no-wrap
-msgid "I am using MS Windows and cannot push with Magit"
-msgstr "MS WindowsではMagitでpushできません"
 
 #. type: Plain text
 #: sed-out/magit.texi:10879
@@ -27669,12 +27414,6 @@ msgstr ""
 "tag signing\")である場合、あなたは@code{$GPG_AGENT_INFO}も同期する必要があり"
 "ます。"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10895 sed-out/magit.texi:10896
-#, no-wrap
-msgid "Expanding a file to show the diff causes it to disappear"
-msgstr "ファイルを展開してdiffを表示するとファイルが消えます"
-
 #. type: Plain text
 #: sed-out/magit.texi:10902
 msgid ""
@@ -27686,12 +27425,6 @@ msgstr ""
 "@code{magit-git-global-arguments}を何らかの理由で設定しています。よって、あな"
 "たはMagit内で@code{magit-git-global-arguments}をカスタマイズしたのを元に戻す"
 "(undo)だけです。"
-
-#. type: appendixsubsec
-#: sed-out/magit.texi:10903 sed-out/magit.texi:10904
-#, no-wrap
-msgid "Point is wrong in the @code{COMMIT_EDITMSG} buffer"
-msgstr "@code{COMMIT_EDITMSG}バッファのpointが間違っています"
 
 #. type: Plain text
 #: sed-out/magit.texi:10908
@@ -27748,12 +27481,6 @@ msgstr ""
 "    (when (or git-commit-mode git-rebase-mode)\n"
 "      (pointback-mode -1))))\n"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10926 sed-out/magit.texi:10927
-#, no-wrap
-msgid "The mode-line information isn't always up-to-date"
-msgstr "モード行の情報が常に最新ではない"
-
 #. type: Plain text
 #: sed-out/magit.texi:10933
 msgid ""
@@ -27801,12 +27528,6 @@ msgstr ""
 "(setq-default mode-line-format\n"
 "              (delete '(vc-mode vc-mode) mode-line-format))\n"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10950 sed-out/magit.texi:10951
-#, no-wrap
-msgid "A branch and tag sharing the same name breaks SOMETHING"
-msgstr "同じ名前を共有するブランチとタグは何かを壊します"
-
 #. type: Plain text
 #: sed-out/magit.texi:10954
 msgid "Or more generally, ambiguous refnames break SOMETHING@."
@@ -27830,12 +27551,6 @@ msgstr ""
 "す。ただし、refnameがあいまいなリポジトリを使用している場合は、発生した問題を"
 "報告してください。簡単な修正があるかどうかを調査できます。"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:10963 sed-out/magit.texi:10964
-#, no-wrap
-msgid "My Git hooks work on the command-line but not inside Magit"
-msgstr "私のGitフックはコマンドラインでは機能しますが、Magit内では機能しません"
-
 #. type: Plain text
 #: sed-out/magit.texi:10973
 msgid ""
@@ -27854,12 +27569,6 @@ msgstr ""
 "@code{GIT_LITERAL_PATHSPECS}を設定することによって行われます。したがって、"
 "@code{unset GIT_LITERAL_PATHSPECS}を使用して、フックスクリプトでこの設定を"
 "オーバーライドできます。"
-
-#. type: appendixsubsec
-#: sed-out/magit.texi:10974 sed-out/magit.texi:10975
-#, no-wrap
-msgid "@code{git-commit-mode} isn't used when committing from the command-line"
-msgstr "コマンドラインからコミットする場合、@code{git-commit-mode}は使用されません"
 
 #. type: Plain text
 #: sed-out/magit.texi:10982
@@ -28004,12 +27713,6 @@ msgstr ""
 "@code{emacs &}を開始(@code{init.el}は@code{server-start}を呼び出す必要があり"
 "ます)し、@code{emacsclient}の使用を再試行します。"
 
-#. type: appendixsubsec
-#: sed-out/magit.texi:11036 sed-out/magit.texi:11037
-#, no-wrap
-msgid "Point ends up inside invisible text when jumping to a file-visiting buffer"
-msgstr "file-visitingバッファにジャンプすると、ポイントは非表示のテキスト内にあります"
-
 #. type: Plain text
 #: sed-out/magit.texi:11045
 msgid ""
@@ -28027,12 +27730,6 @@ msgstr ""
 "代わりに@code{magit-diff-visit-file-hook}を使用してテキストを表示することがで"
 "きます。おそらく、@code{reveal-post-command}を使用するか、Orgバッファ"
 "@code{org-reveal}を使用します。"
-
-#. type: appendixsubsec
-#: sed-out/magit.texi:11046 sed-out/magit.texi:11047
-#, no-wrap
-msgid "I am unable to stage when using Tramp from MS Windows"
-msgstr "MS-WindowsからEmacsのTrampモードを使用するとステージできません"
 
 #. type: Plain text
 #: sed-out/magit.texi:11052
@@ -28097,12 +27794,6 @@ msgstr ""
 "る場合にも他のオプションがあり、入力すると表示されます。詳細については"
 "@uref{https://magit.vc/manual/transient/Saving-Values.html#Saving-Values}を参"
 "照してください。"
-
-#. type: chapter
-#: sed-out/magit.texi:11077 sed-out/magit.texi:11078
-#, no-wrap
-msgid "Debugging Tools"
-msgstr "Debugging Tools"
 
 #. type: Plain text
 #: sed-out/magit.texi:11084
@@ -28247,15 +27938,3 @@ msgstr "こちらもご覧ください(@ref{Debugging,,,with-editor,})"
 #: sed-out/magit.texi:11156
 msgid "Please also see @ref{FAQ}."
 msgstr "どうぞこちらもご覧下さい @ref{FAQ}"
-
-#. type: appendix
-#: sed-out/magit.texi:11157 sed-out/magit.texi:11158
-#, no-wrap
-msgid "Keystroke Index"
-msgstr "Keystroke Index"
-
-#. type: appendix
-#: sed-out/magit.texi:11162 sed-out/magit.texi:11163
-#, no-wrap
-msgid "Function and Command Index"
-msgstr "Function and Command Index"


### PR DESCRIPTION
Hello,

This is a continuation from #1, migrating from deprecated `po4a-updatepo` and `po4a-translate` to integrated `po4a` command.

The `*.po`, `*.texi`, and `*.info` files are not updated for this time.

Update: Add PO files to prerequisites:

<details>

```diff
diff --git a/docs/docs-ja/Makefile b/docs/docs-ja/Makefile
index 5887c8cf..d167f73f 100644
--- a/docs/docs-ja/Makefile
+++ b/docs/docs-ja/Makefile
@@ -52,7 +52,7 @@ $(PO4A_CONFIG):
        TRANSLATE_RAW_DIR=$(TRANSLATE_RAW_DIR)          \
                ./generate-po4a-config > $@
 
-$(TARGET_TRANSLATE_RAW_TEXI) &: $(TARGET_SED_OUT) $(PO4A_CONFIG)
+$(TARGET_TRANSLATE_RAW_TEXI) &: $(TARGET_SED_OUT) $(TARGET_PO) $(PO4A_CONFIG)
        po4a $(PO4A_CONFIG)
 
 $(TARGET_TEXI): %.ja.texi : $(TRANSLATE_RAW_DIR)/%.ja.texi
```

</details>

Update2: Correctly set `pot` specifiers for split mode, update PO files, and generate translations.

Best,